### PR TITLE
fix fop docbook.xsl path for macos, add syntax version to example pro…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,7 @@ protoc-gen-doc
 *.o
 *.pro.user*
 qrc_*
+
+.DS_Store
+.qmake.cache
+.qmake.stash

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -38,22 +38,28 @@ future.
 ## Mac OS X
 
 ### Install Build Tools
+First, you need to have Xcode and Xcode Command Line Tools installed. You can follow [this instruction](https://railsapps.github.io/xcode-command-line-tools.html) to install both.
 
-If you do not have Homebrew, install it first, see [here](http://brew.sh) for instructions.
+Then, you need to install Homebrew, the mighty package manager on macos, see [Homebrew site](http://brew.sh) for instructions.
 
-Then, at a Terminal prompt, run:
+Finally, at a Terminal prompt, run:
 ```
 brew update
-brew install qt5 protobuf
+brew install qt5 protobuf fop docbook-xsl
 brew link --force qt5
 export PROTOBUF_PREFIX=$(brew --prefix protobuf)
 git clone git@github.com:estan/protoc-gen-doc.git
 cd protoc-gen-doc
 qmake
 make
+cd examples
+make clean
+make
 ```
+Basically, this installed packages required to build `protoc-gen-doc`, then clone the master git repo (or you can use your own fork) and build from the source. Finally, it generates the doc from example protobuf files.
 
-in the top-level directory to build the plugin. This will produce the plugin
+
+In the top-level directory to build the plugin. This will produce the plugin
 executable (`protoc-gen-doc`). `PROTOBUF_PREFIX` is the path to where the protobuf
 library was installed. There's no install step, just copy the executable to where you
 want it, or specify the path to `protoc-gen-doc` with --plugin.

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -35,12 +35,15 @@ zip`. MSVC is currently the only supported compiler on Windows. Building with Mi
 should work, but the `zip` target is not available. I'll try to fix this in the
 future.
 
-## Mac OS X
+## macOS
 
 ### Install Build Tools
-First, you need to have Xcode and Xcode Command Line Tools installed. You can follow [this instruction](https://railsapps.github.io/xcode-command-line-tools.html) to install both.
+First, you need to have Xcode and Xcode Command Line Tools installed. You can follow 
+[this instruction](https://railsapps.github.io/xcode-command-line-tools.html) to 
+install both.
 
-Then, you need to install Homebrew, the mighty package manager on macos, see [Homebrew site](http://brew.sh) for instructions.
+Then, you need to install Homebrew, the mighty package manager on macOS, see 
+[Homebrew site](http://brew.sh) for instructions.
 
 Finally, at a Terminal prompt, run:
 ```
@@ -52,12 +55,10 @@ git clone git@github.com:estan/protoc-gen-doc.git
 cd protoc-gen-doc
 qmake
 make
-cd examples
-make clean
-make
 ```
-Basically, this installed packages required to build `protoc-gen-doc`, then clone the master git repo (or you can use your own fork) and build from the source. Finally, it generates the doc from example protobuf files.
-
+Basically, this installed packages required to build `protoc-gen-doc`, then clone 
+the master git repo (or you can use your own fork) and build from the source. 
+Finally, it generates the doc from example protobuf files.
 
 In the top-level directory to build the plugin. This will produce the plugin
 executable (`protoc-gen-doc`). `PROTOBUF_PREFIX` is the path to where the protobuf
@@ -67,5 +68,26 @@ want it, or specify the path to `protoc-gen-doc` with --plugin.
 Note that on Mac OS X, the protobuf library should be built with with clang
 (`CC=clang` and `CXX=clang++`), or you'll get linker errors.
 
-If you need even more detailed instructions, you can look at the Travis build file (https://github.com/estan/protoc-gen-doc/blob/master/.travis.yml). The tool is built and tested regularly on Mac OS X, and that file contains the exact steps.
+If you need even more detailed instructions, you can look at the [Travis build file] (https://github.com/estan/protoc-gen-doc/blob/master/.travis.yml). 
+The tool is built and tested regularly on Mac OS X, and that file contains 
+the exact steps.
 
+# Building the Examples
+
+To get you started, you can try the examples:
+```
+cd examples
+make clean
+make
+```
+
+Please note that you need to set `DOCBOOK_XSL` based on your OS and the version of `docbook-sxl` package:
+```
+Default: 
+/usr/share/xml/docbook/xsl-stylesheets-1.79.1/fo/docbook.xsl
+
+macOS docbook-xsl installed by Homebrew:
+DOCBOOK_XSL?=/usr/local/Cellar/docbook-xsl/1.79.1/docbook-xsl-ns/fo/docbook.xsl
+```
+
+This would generate `docbook`, `html`, `md` and `pdf` documents in `examples/doc`.

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,12 +1,4 @@
-UNAME := $(shell uname)
-ifeq ($(UNAME), Darwin)
-	# macos, assuming docbook and docbook-xsl are installed using Homebrew to the default path
-	DOCBOOK_XSL?=/usr/local/Cellar/docbook-xsl/1.79.1/docbook-xsl-ns/fo/docbook.xsl
-else
-	# non-macos
-	DOCBOOK_XSL?=/usr/share/xml/docbook/xsl-stylesheets-1.79.1/fo/docbook.xsl
-endif
-
+DOCBOOK_XSL?=/usr/share/xml/docbook/xsl-stylesheets-1.79.1/fo/docbook.xsl
 export PATH := ..:$(PATH)
 
 all: doc/example.md doc/example.html doc/example.docbook doc/example.pdf

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,4 +1,11 @@
-DOCBOOK_XSL?=/usr/share/xml/docbook/xsl-stylesheets-1.79.1/fo/docbook.xsl
+UNAME := $(shell uname)
+ifeq ($(UNAME), Darwin)
+	# macos, assuming docbook and docbook-xsl are installed using Homebrew to the default path
+	DOCBOOK_XSL?=/usr/local/Cellar/docbook-xsl/1.79.1/docbook-xsl-ns/fo/docbook.xsl
+else
+	# non-macos
+	DOCBOOK_XSL?=/usr/share/xml/docbook/xsl-stylesheets-1.79.1/fo/docbook.xsl
+endif
 
 export PATH := ..:$(PATH)
 

--- a/examples/proto/Booking.proto
+++ b/examples/proto/Booking.proto
@@ -6,6 +6,7 @@
  *
  * Author: Elvis Stansvik
  */
+syntax = "proto2";
 package com.example;
 
 /**

--- a/examples/proto/Customer.proto
+++ b/examples/proto/Customer.proto
@@ -1,7 +1,7 @@
 /// This file has messages for describing a customer.
 ///
 /// Author: Elvis Stansvik
-
+syntax = "proto2";
 package com.example;
 
 // Use /// or /** */ to document messages, fields and enums.

--- a/examples/proto/Vehicle.proto
+++ b/examples/proto/Vehicle.proto
@@ -1,5 +1,5 @@
 /** Messages describing manufacturers / vehicles. */
-
+syntax = "proto2";
 package com.example;
 
 /**


### PR DESCRIPTION
…to files, update macos build instructions, update .gitignore to ignore qt cache and stash

@estan 

here is the PR related to #269 