### PR TITLE
Add .qmake.stash to .gitignore [ci skip]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ protoc-gen-doc
 *.o
 *.pro.user*
 qrc_*
+.qmake.stash


### PR DESCRIPTION
Resolves #279 by adding _.qmake.stash` to the .gitignore file