### PR TITLE
Add support for C#, Go, PHP, Python, and Ruby scalar types

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -2,7 +2,7 @@ DOCBOOK_XSL?=/usr/share/xml/docbook/xsl-stylesheets-1.79.1/fo/docbook.xsl
 
 export PATH := ..:$(PATH)
 
-all: doc/example.md doc/example.html doc/example.docbook doc/example.pdf doc/example.json
+all: doc/example.md doc/example.html doc/example.docbook doc/example.pdf doc/example.json doc/example_types.md
 
 doc/example.md: proto/*.proto ../protoc-gen-doc
 	protoc --doc_out=markdown,example.md:doc proto/*.proto
@@ -24,6 +24,9 @@ doc/example.pdf: doc/example.docbook
 
 doc/example.json: proto/*.proto ../protoc-gen-doc
 	protoc --doc_out=json,example.json:doc proto/*.proto
+
+doc/example_types.md: proto/*.proto ../protoc-gen-doc
+	protoc --doc_out=./templates/example_types.mustache,example_types.md:doc proto/*.proto
 
 clean:
 	-rm doc/*

--- a/examples/doc/example.md
+++ b/examples/doc/example.md
@@ -52,7 +52,7 @@ Represents the status of a vehicle booking.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | id | [int32](#int32) | required | Unique booking status ID. |
-| description | [string](#string) | required | Booking status description. E.g. &quot;Active&quot;. |
+| description | [string](#string) | required | Booking status description. E.g. "Active". |
 
 
 
@@ -123,7 +123,7 @@ Represents a manufacturer of cars.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | id | [int32](#int32) | required | The unique manufacturer ID. |
-| code | [string](#string) | required | A manufacturer code, e.g. &quot;DKL4P&quot;. |
+| code | [string](#string) | required | A manufacturer code, e.g. "DKL4P". |
 | details | [string](#string) | optional | Manufacturer details (minimum orders et.c.). |
 | category | [Manufacturer.Category](#com.example.Manufacturer.Category) | optional | Manufacturer category. Default: CATEGORY_EXTERNAL |
 
@@ -135,8 +135,8 @@ Represents a vehicle model.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | id | [string](#string) | required | The unique model ID. |
-| model_code | [string](#string) | required | The car model code, e.g. &quot;PZ003&quot;. |
-| model_name | [string](#string) | required | The car model name, e.g. &quot;Z3&quot;. |
+| model_code | [string](#string) | required | The car model code, e.g. "PZ003". |
+| model_name | [string](#string) | required | The car model name, e.g. "Z3". |
 | daily_hire_rate_dollars | [sint32](#sint32) | required | Dollars per day. |
 | daily_hire_rate_cents | [sint32](#sint32) | required | Cents per day. |
 
@@ -161,12 +161,12 @@ Represents a vehicle that can be hired.
 
 <a name="com.example.Vehicle.Category"/>
 ### Vehicle.Category
-Represents a vehicle category. E.g. &quot;Sedan&quot; or &quot;Truck&quot;.
+Represents a vehicle category. E.g. "Sedan" or "Truck".
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| code | [string](#string) | required | Category code. E.g. &quot;S&quot;. |
-| description | [string](#string) | required | Category name. E.g. &quot;Sedan&quot;. |
+| code | [string](#string) | required | Category code. E.g. "S". |
+| description | [string](#string) | required | Category name. E.g. "Sedan". |
 
 
 

--- a/examples/doc/example_types.md
+++ b/examples/doc/example_types.md
@@ -1,0 +1,26 @@
+# All the Types
+<a name="top"/>
+
+## Table of Contents
+* [Scalar Value Types](#scalar-value-types)
+
+<a name="scalar-value-types"/>
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | C# Type | Go Type | Java Type | PHP Type | Python Type | Ruby Type |
+| ----------- | ----- | -------- | ------- | --------| --------- | -------- | ----------- | --------- |
+| <a name="double"/> double |  | double | double | float64 | double | float | float | Float |
+| <a name="float"/> float |  | float | float | float32 | float | float | float | Float |
+| <a name="int32"/> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int32 | int | integer | int | Bignum or Fixnum (as required) |
+| <a name="int64"/> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int64 | long | integer/string | int/long | Bignum |
+| <a name="uint32"/> uint32 | Uses variable-length encoding. | uint32 | uint | uint32 | int | integer | int/long | Bignum or Fixnum (as required) |
+| <a name="uint64"/> uint64 | Uses variable-length encoding. | uint64 | ulong | uint64 | long | integer/string | int/long | Bignum or Fixnum (as required) |
+| <a name="sint32"/> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int32 | int | integer | int | Bignum or Fixnum (as required) |
+| <a name="sint64"/> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int64 | long | integer/string | int/long | Bignum |
+| <a name="fixed32"/> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | uint | uint32 | int | integer | int | Bignum or Fixnum (as required) |
+| <a name="fixed64"/> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | ulong | uint64 | long | integer/string | int/long | Bignum |
+| <a name="sfixed32"/> sfixed32 | Always four bytes. | int32 | int | int32 | int | integer | int | Bignum or Fixnum (as required) |
+| <a name="sfixed64"/> sfixed64 | Always eight bytes. | int64 | long | int64 | long | integer/string | int/long | Bignum |
+| <a name="bool"/> bool |  | bool | bool | bool | boolean | boolean | boolean | TrueClass/FalseClass |
+| <a name="string"/> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | string | string | String | string | str/unicode | String (UTF-8) |
+| <a name="bytes"/> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | []byte | ByteString | string | str | String (ASCII-8BIT) |

--- a/examples/templates/example_types.mustache
+++ b/examples/templates/example_types.mustache
@@ -1,0 +1,14 @@
+# All the Types
+<a name="top"/>
+
+## Table of Contents
+* [Scalar Value Types](#scalar-value-types)
+
+<a name="scalar-value-types"/>
+## Scalar Value Types
+
+| .proto Type | Notes | C++ Type | C# Type | Go Type | Java Type | PHP Type | Python Type | Ruby Type |
+| ----------- | ----- | -------- | ------- | --------| --------- | -------- | ----------- | --------- |
+{{#scalar_value_types}}
+| <a name="{{scalar_value_proto_type}}"/> {{scalar_value_proto_type}} | {{scalar_value_notes}} | {{scalar_value_cpp_type}} | {{scalar_value_cs_type}} | {{scalar_value_go_type}} | {{scalar_value_java_type}} | {{scalar_value_php_type}} | {{scalar_value_python_type}} | {{scalar_value_ruby_type}} |
+{{/scalar_value_types}}

--- a/templates/scalar_value_types.json
+++ b/templates/scalar_value_types.json
@@ -3,105 +3,165 @@
         "scalar_value_proto_type": "double",
         "scalar_value_notes": "",
         "scalar_value_cpp_type": "double",
+        "scalar_value_cs_type": "double",
+        "scalar_value_go_type": "float64",
         "scalar_value_java_type": "double",
-        "scalar_value_python_type": "float"
+        "scalar_value_php_type": "float",
+        "scalar_value_python_type": "float",
+        "scalar_value_ruby_type": "Float"
     },
     {
         "scalar_value_proto_type": "float",
         "scalar_value_notes": "",
         "scalar_value_cpp_type": "float",
+        "scalar_value_cs_type": "float",
+        "scalar_value_go_type": "float32",
         "scalar_value_java_type": "float",
-        "scalar_value_python_type": "float"
+        "scalar_value_php_type": "float",
+        "scalar_value_python_type": "float",
+        "scalar_value_ruby_type": "Float"
     },
     {
         "scalar_value_proto_type": "int32",
         "scalar_value_notes": "Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead.",
         "scalar_value_cpp_type": "int32",
+        "scalar_value_cs_type": "int",
+        "scalar_value_go_type": "int32",
         "scalar_value_java_type": "int",
-        "scalar_value_python_type": "int"
+        "scalar_value_php_type": "integer",
+        "scalar_value_python_type": "int",
+        "scalar_value_ruby_type": "Bignum or Fixnum (as required)"
     },
     {
         "scalar_value_proto_type": "int64",
         "scalar_value_notes": "Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead.",
         "scalar_value_cpp_type": "int64",
+        "scalar_value_cs_type": "long",
+        "scalar_value_go_type": "int64",
         "scalar_value_java_type": "long",
-        "scalar_value_python_type": "int/long"
+        "scalar_value_php_type": "integer/string",
+        "scalar_value_python_type": "int/long",
+        "scalar_value_ruby_type": "Bignum"
     },
     {
         "scalar_value_proto_type": "uint32",
         "scalar_value_notes": "Uses variable-length encoding.",
         "scalar_value_cpp_type": "uint32",
+        "scalar_value_cs_type": "uint",
+        "scalar_value_go_type": "uint32",
         "scalar_value_java_type": "int",
-        "scalar_value_python_type": "int/long"
+        "scalar_value_php_type": "integer",
+        "scalar_value_python_type": "int/long",
+        "scalar_value_ruby_type": "Bignum or Fixnum (as required)"
     },
     {
         "scalar_value_proto_type": "uint64",
         "scalar_value_notes": "Uses variable-length encoding.",
         "scalar_value_cpp_type": "uint64",
+        "scalar_value_cs_type": "ulong",
+        "scalar_value_go_type": "uint64",
         "scalar_value_java_type": "long",
-        "scalar_value_python_type": "int/long"
+        "scalar_value_php_type": "integer/string",
+        "scalar_value_python_type": "int/long",
+        "scalar_value_ruby_type": "Bignum or Fixnum (as required)"
     },
     {
         "scalar_value_proto_type": "sint32",
         "scalar_value_notes": "Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s.",
         "scalar_value_cpp_type": "int32",
+        "scalar_value_cs_type": "int",
+        "scalar_value_go_type": "int32",
         "scalar_value_java_type": "int",
-        "scalar_value_python_type": "int"
+        "scalar_value_php_type": "integer",
+        "scalar_value_python_type": "int",
+        "scalar_value_ruby_type": "Bignum or Fixnum (as required)"
     },
     {
         "scalar_value_proto_type": "sint64",
         "scalar_value_notes": "Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s.",
         "scalar_value_cpp_type": "int64",
+        "scalar_value_cs_type": "long",
+        "scalar_value_go_type": "int64",
         "scalar_value_java_type": "long",
-        "scalar_value_python_type": "int/long"
+        "scalar_value_php_type": "integer/string",
+        "scalar_value_python_type": "int/long",
+        "scalar_value_ruby_type": "Bignum"
     },
     {
         "scalar_value_proto_type": "fixed32",
         "scalar_value_notes": "Always four bytes. More efficient than uint32 if values are often greater than 2^28.",
         "scalar_value_cpp_type": "uint32",
+        "scalar_value_cs_type": "uint",
+        "scalar_value_go_type": "uint32",
         "scalar_value_java_type": "int",
-        "scalar_value_python_type": "int"
+        "scalar_value_php_type": "integer",
+        "scalar_value_python_type": "int",
+        "scalar_value_ruby_type": "Bignum or Fixnum (as required)"
     },
     {
         "scalar_value_proto_type": "fixed64",
         "scalar_value_notes": "Always eight bytes. More efficient than uint64 if values are often greater than 2^56.",
         "scalar_value_cpp_type": "uint64",
+        "scalar_value_cs_type": "ulong",
+        "scalar_value_go_type": "uint64",
         "scalar_value_java_type": "long",
-        "scalar_value_python_type": "int/long"
+        "scalar_value_php_type": "integer/string",
+        "scalar_value_python_type": "int/long",
+        "scalar_value_ruby_type": "Bignum"
     },
     {
         "scalar_value_proto_type": "sfixed32",
         "scalar_value_notes": "Always four bytes.",
         "scalar_value_cpp_type": "int32",
+        "scalar_value_cs_type": "int",
+        "scalar_value_go_type": "int32",
         "scalar_value_java_type": "int",
-        "scalar_value_python_type": "int"
+        "scalar_value_php_type": "integer",
+        "scalar_value_python_type": "int",
+        "scalar_value_ruby_type": "Bignum or Fixnum (as required)"
     },
     {
         "scalar_value_proto_type": "sfixed64",
         "scalar_value_notes": "Always eight bytes.",
         "scalar_value_cpp_type": "int64",
+        "scalar_value_cs_type": "long",
+        "scalar_value_go_type": "int64",
         "scalar_value_java_type": "long",
-        "scalar_value_python_type": "int/long"
+        "scalar_value_php_type": "integer/string",
+        "scalar_value_python_type": "int/long",
+        "scalar_value_ruby_type": "Bignum"
     },
     {
         "scalar_value_proto_type": "bool",
         "scalar_value_notes": "",
         "scalar_value_cpp_type": "bool",
+        "scalar_value_cs_type": "bool",
+        "scalar_value_go_type": "bool",
         "scalar_value_java_type": "boolean",
-        "scalar_value_python_type": "boolean"
+        "scalar_value_php_type": "boolean",
+        "scalar_value_python_type": "boolean",
+        "scalar_value_ruby_type": "TrueClass/FalseClass"
     },
     {
         "scalar_value_proto_type": "string",
         "scalar_value_notes": "A string must always contain UTF-8 encoded or 7-bit ASCII text.",
         "scalar_value_cpp_type": "string",
+        "scalar_value_cs_type": "string",
+        "scalar_value_go_type": "string",
         "scalar_value_java_type": "String",
-        "scalar_value_python_type": "str/unicode"
+        "scalar_value_php_type": "string",
+        "scalar_value_python_type": "str/unicode",
+        "scalar_value_ruby_type": "String (UTF-8)"
     },
     {
         "scalar_value_proto_type": "bytes",
         "scalar_value_notes": "May contain any arbitrary sequence of bytes.",
         "scalar_value_cpp_type": "string",
+        "scalar_value_cs_type": "ByteString",
+        "scalar_value_go_type": "[]byte",
         "scalar_value_java_type": "ByteString",
-        "scalar_value_python_type": "str"
+        "scalar_value_php_type": "string",
+        "scalar_value_python_type": "str",
+        "scalar_value_ruby_type": "String (ASCII-8BIT)"
     }
 ]


### PR DESCRIPTION
I noticed that scalar value types for a few languages were missing, so I've added them here. Specifically, I've made the following available for the mustache templates:

* `scalar_value_cs_type`
* `scalar_value_go_type`
* `scalar_value_php_type`
* `scalar_value_python_type`
* `scalar_value_ruby_type`

List of proto to language types can be found [here](https://developers.google.com/protocol-buffers/docs/proto3#scalar)