### PR TITLE
Add make dist for building dists for windows, linux, and osx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/dist
 /gen_fixtures
 /protoc-gen-doc
 /test/*.dat

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: bench test build
+.PHONY: bench test build dist
 
 generate:
 	@go generate
@@ -19,3 +19,6 @@ examples: build
 	@protoc --plugin=protoc-gen-doc --doc_out=examples/doc --doc_opt=json,example.json examples/proto/*.proto
 	@protoc --plugin=protoc-gen-doc --doc_out=examples/doc --doc_opt=markdown,example.md examples/proto/*.proto
 	@protoc --plugin=protoc-gen-doc --doc_out=examples/doc --doc_opt=examples/templates/asciidoc.tmpl,example.txt examples/proto/*.proto
+
+dist:
+	@./dist.sh

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ The plugin executable must be in `PATH` for this to work.
 
 Alternatively, you can specify a pre-built/not in `PATH` binary using the `--plugin` option.
 
-    protoc --plugin=protoc-gen-doc=./protoc-gen-doc \
+    protoc \
+      --plugin=protoc-gen-doc=./protoc-gen-doc \
       --doc_out=./doc \
       --doc_opt=html,index.html \
       proto/*.proto

--- a/dist.sh
+++ b/dist.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+package_dist() {
+  local build_dir="${1}"
+  local target="${2}"
+
+  pushd "${build_dir}" >/dev/null
+  tar czf "${target}.tar.gz" "${target}"
+  mv "${target}.tar.gz" "${DIR}/dist"
+  popd >/dev/null
+}
+
+build_dist() {
+  local os="${1}"
+  local version="${2}"
+  local go_version="${3}"
+
+  local build=$(mktemp -d /tmp/protoc-gen-doc.XXXXXX)
+  local target="protoc-gen-doc-${version}.${os}-amd64.${go_version}"
+
+  local ext=""
+  if [ "${os}" = "windows" ]; then ext=".exe"; fi
+
+  echo -n "Building ${target}..."
+  GOOS="${os}" GOARCH=amd64 CGO_ENABLED=0 \
+    go build -ldflags="-s -w" -o "${build}/${target}/protoc-gen-doc${ext}" ./cmd/... || exit 1
+
+  package_dist "${build}" "${target}"
+  echo "done."
+}
+
+main() {
+  rm -rf "${DIR}/dist"
+  mkdir -p "${DIR}/dist"
+
+  local app_version=$(cat ${DIR}/version.go | grep "const VERSION" | awk '{print $NF}' | sed 's/"//g')
+  local go_version=$(go version | awk '{print $3}')
+
+  for target in windows linux darwin; do
+    build_dist "${target}" "${app_version}" "${go_version}"
+  done
+}
+
+main "$@"

--- a/dist.sh
+++ b/dist.sh
@@ -29,6 +29,7 @@ build_dist() {
     go build -ldflags="-s -w" -o "${build}/${target}/protoc-gen-doc${ext}" ./cmd/... || exit 1
 
   package_dist "${build}" "${target}"
+  rm -rf "${build}"
   echo "done."
 }
 
@@ -36,7 +37,7 @@ main() {
   rm -rf "${DIR}/dist"
   mkdir -p "${DIR}/dist"
 
-  local app_version=$(cat ${DIR}/version.go | grep "const VERSION" | awk '{print $NF}' | sed 's/"//g')
+  local app_version=$(grep "const VERSION" "${DIR}/version.go" | awk '{print $NF }' | tr -d '"')
   local go_version=$(go version | awk '{print $3}')
 
   for target in windows linux darwin; do

--- a/version.go
+++ b/version.go
@@ -1,0 +1,3 @@
+package protoc_gen_doc
+
+const VERSION = "1.0.0"


### PR DESCRIPTION
Fixes #307 

Similar to how [oauth2_proxy](https://github.com/bitly/oauth2_proxy) packages its binaries, I've added `make dist` that will generate amd64 binaries for Windows, Linux, and Darwin.

The intent is to add these to releases so that users can just fetch the tar file for their platform and extract, without having to install go or anything.