### PR TITLE
Update docker to support single/multi file generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ docker run --rm \
   pseudomuto/protoc-gen-doc
 ```
 
-By default HTML documentation is generated in `/out/index.html`. This can be changed by passing the `--doc_opt`
-parameter to the container.
+By default HTML documentation is generated in `/out/index.html` for all `.proto` files in the `/protos` volume. This can
+be changed by passing the `--doc_opt` parameter to the container.
 
-For example, to generate Markdown for the examples:
+For example, to generate Markdown for all the examples:
 
 ```
 docker run --rm \
@@ -51,6 +51,21 @@ docker run --rm \
   -v $(pwd)/examples/proto:/protos \
   pseudomuto/protoc-gen-doc --doc_opt=md,docs.md
 ```
+
+You can also generate documentation for a single file. This can be done by passing the file(s) to the command:
+
+```
+docker run --rm \
+  -v $(pwd)/examples/doc:/out \
+  -v $(pwd)/examples/proto:/protos \
+  pseudomuto/protoc-gen-doc --doc_opt=md,docs.md /protos/Booking.proto [OPTIONALLY LIST MORE FILES]
+```
+
+_**Remember**_: Paths should be from within the container, not the host!
+
+> NOTE: Due to the way wildcard expansion works with docker you cannot use a wildcard path (e.g. `protos/*.proto`) in
+the file list. To get around this, if no files are passed, the container will generate docs for `protos/*.proto`, which
+can be changed by mounting different volumes.
 
 ### Simple Usage
 

--- a/script/entrypoint.sh
+++ b/script/entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-# this is required because of the wildcard expansion. Passing protos/*.proto in CMD gets escaped -_-.
-exec protoc --doc_out=/out "$@" protos/*.proto
+# this is required because of the wildcard expansion. Passing protos/*.proto in CMD gets escaped -_-. So instead leaving
+# off the [FILES] will put protos/*.proto in from here which will expand correctly.
+args=("$@")
+if [ "${#args[@]}" -lt 2 ]; then args+=(protos/*.proto); fi
+
+exec protoc --doc_out=/out "${args[@]}"


### PR DESCRIPTION
@aschrijver

Currently, because of the way docker handles wildcard expansion, there's no way to generate docs for a single file (or a few specific ones).

This is because the `entrypoint.sh` script hard codes `protos/*.proto` since it can handle the expansion.

To get around this, I've updated the script to add `protos/*.proto` only if the current arg count < 2. 

This means the following all work:

```bash
# generate HTML for all protos in /protos
docker run --rm \
  -v $(pwd)/protos:/protos:ro \
  -v $(pwd)/docs:/out \
  pseudomuto/protoc-gen-doc

# generate Markdown for all protos in /protos
docker run --rm \
  -v $(pwd)/protos:/protos:ro \
  -v $(pwd)/docs:/out \
  pseudomuto/protoc-gen-doc --doc_out=markdown,docs.md

# generate JSON for two specific protos
docker run --rm \
  -v $(pwd)/protos:/protos:ro \
  -v $(pwd)/docs:/out \
  pseudomuto/protoc-gen-doc --doc_out=json,docs.json /protos/proto1.proto /protos/proto2.proto
```

The docker problem still exists. For example, the following would not work since the wildcard expansion gets _magically_ escaped.

```
docker run --rm \
  -v $(pwd)/protos:/protos:ro \
  -v $(pwd)/docs:/out \
  pseudomuto/protoc-gen-doc --doc_out=markdown,docs.md /protos/*.proto
```