### PR TITLE
Go port - fixes to markdown.tmpl ToC section

### DIFF
--- a/resources/markdown.tmpl
+++ b/resources/markdown.tmpl
@@ -3,22 +3,17 @@
 
 ## Table of Contents
 {{range .Files}}
-{{$file_name := .Name}}
-* [{{.Name}}](#{{.Name}})
-  {{range .Messages}}
-    * [{{.LongName}}](#{{.FullName}})
+{{$file_name := .Name}}- [{{.Name}}](#{{.Name}})
+  {{range .Messages}}  - [{{.LongName}}](#{{.FullName}})
   {{end}}
-  {{range .Enums}}
-    * [{{.LongName}}](#{{.FullName}})
+  {{range .Enums}}  - [{{.LongName}}](#{{.FullName}})
   {{end}}
-  {{range .Extensions}}
-    * [File-level Extensions](#{{$file_name}}-extensions)
+  {{range .Extensions}}  - [File-level Extensions](#{{$file_name}}-extensions)
   {{end}}
-  {{range .Services}}
-    * [{{.Name}}](#{{.FullName}})
+  {{range .Services}}  - [{{.Name}}](#{{.FullName}})
   {{end}}
 {{end}}
-* [Scalar Value Types](#scalar-value-types)
+- [Scalar Value Types](#scalar-value-types)
 
 {{range .Files}}
 {{$file_name := .Name}}


### PR DESCRIPTION
Some changes to the table of contents for markdown, so that there are no superfluous line-feeds.

Note that: 
- there is still a line-feed before `.Name` of the file. This is probably inside of the variable
- the file .Description is empty, not rendered to output
- whitespace is stripped from code snippets