### PR TITLE
Add support for -help, -h, and -version flags

### DIFF
--- a/cmd/protoc-gen-doc/main.go
+++ b/cmd/protoc-gen-doc/main.go
@@ -23,6 +23,20 @@ import (
 )
 
 func main() {
+	flags := gendoc.ParseFlags(os.Stdout, os.Args)
+
+	if flags.HasMatch() {
+		if flags.ShowHelp() {
+			flags.PrintHelp()
+		}
+
+		if flags.ShowVersion() {
+			flags.PrintVersion()
+		}
+
+		os.Exit(flags.Code())
+	}
+
 	input, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {
 		log.Fatalf("Could not read contents from stdin")

--- a/flags.go
+++ b/flags.go
@@ -1,0 +1,74 @@
+package gendoc
+
+import (
+	"flag"
+	"fmt"
+	"io"
+)
+
+// Flags contains details about the CLI invocation of protoc-gen-doc
+type Flags struct {
+	appName     string
+	flagSet     *flag.FlagSet
+	err         error
+	showHelp    bool
+	showVersion bool
+	writer      io.Writer
+}
+
+// Code returns the status code to exit with after handling the supplied flags
+func (f *Flags) Code() int {
+	if f.err != nil {
+		return 1
+	}
+
+	return 0
+}
+
+// HasMatch returns whether or not the supplied args are matches. For example, passing `--help` will match, or some
+// unknown parameter, but passing nothing will not.
+func (f *Flags) HasMatch() bool {
+	return f.ShowHelp() || f.ShowVersion()
+}
+
+// ShowHelp determines whether or not to show the help message
+func (f *Flags) ShowHelp() bool {
+	return f.err != nil || f.showHelp
+}
+
+// ShowVersion determines whether or not to show the version message
+func (f *Flags) ShowVersion() bool {
+	return f.showVersion
+}
+
+// PrintHelp prints the usage string including all flags to the `io.Writer` that was supplied to the `Flags` object.
+func (f *Flags) PrintHelp() {
+	fmt.Fprintf(f.writer, "Usage of %s:\n\n", f.appName)
+	fmt.Fprintf(f.writer, "FLAGS\n")
+	f.flagSet.PrintDefaults()
+}
+
+// PrintVersion prints the version string to the `io.Writer` that was supplied to the `Flags` object.
+func (f *Flags) PrintVersion() {
+	fmt.Fprintf(f.writer, "%s version %s\n", f.appName, VERSION)
+}
+
+// ParseFlags parses the supplied options are returns a `Flags` object to the caller.
+//
+// Parameters:
+//   * `w` - the `io.Writer` to use for printing messages (help, version, etc.)
+//   * `args` - the set of args the program was invoked with (typically `os.Args`)
+func ParseFlags(w io.Writer, args []string) *Flags {
+	f := Flags{appName: args[0], writer: w}
+
+	f.flagSet = flag.NewFlagSet(args[0], flag.ContinueOnError)
+	f.flagSet.BoolVar(&f.showHelp, "help", false, "Show this help message")
+	f.flagSet.BoolVar(&f.showVersion, "version", false, fmt.Sprintf("Print the current version (%v)", VERSION))
+	f.flagSet.SetOutput(w)
+
+	// prevent showing help on parse error
+	f.flagSet.Usage = func() {}
+
+	f.err = f.flagSet.Parse(args[1:])
+	return &f
+}

--- a/flags.go
+++ b/flags.go
@@ -6,6 +6,19 @@ import (
 	"io"
 )
 
+const helpMessage = `
+This is a protoc plugin that is used to generate documentation from your protobuf files. Invocation is controlled by
+using the doc_opt and doc_out options for protoc.
+
+EXAMPLE: Generate HTML docs
+protoc --doc_out=. --doc_opt=html,index.html protos/*.proto
+
+EXAMPLE: Use a custom template
+protoc --doc_out=. --doc_opt=custom.tmpl,docs.txt protos/*.proto
+
+See https://github.com/pseudomuto/protoc-gen-doc for more details.
+`
+
 // Flags contains details about the CLI invocation of protoc-gen-doc
 type Flags struct {
 	appName     string
@@ -43,7 +56,8 @@ func (f *Flags) ShowVersion() bool {
 
 // PrintHelp prints the usage string including all flags to the `io.Writer` that was supplied to the `Flags` object.
 func (f *Flags) PrintHelp() {
-	fmt.Fprintf(f.writer, "Usage of %s:\n\n", f.appName)
+	fmt.Fprintf(f.writer, "Usage of %s:\n", f.appName)
+	fmt.Fprintf(f.writer, "%s\n", helpMessage)
 	fmt.Fprintf(f.writer, "FLAGS\n")
 	f.flagSet.PrintDefaults()
 }

--- a/flags_test.go
+++ b/flags_test.go
@@ -1,0 +1,88 @@
+package gendoc_test
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/pseudomuto/protoc-gen-doc"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type FlagsTest struct {
+	suite.Suite
+}
+
+func TestFlags(t *testing.T) {
+	suite.Run(t, new(FlagsTest))
+}
+
+func (assert *FlagsTest) TestCode() {
+	f := gendoc.ParseFlags(nil, []string{"app", "-help"})
+	assert.Equal(0, f.Code())
+
+	f = gendoc.ParseFlags(nil, []string{"app", "-whoawhoawhoa"})
+	assert.Equal(1, f.Code())
+}
+
+func (assert *FlagsTest) TestHasMatch() {
+	f := gendoc.ParseFlags(nil, []string{"app", "-help"})
+	assert.True(f.HasMatch())
+
+	f = gendoc.ParseFlags(nil, []string{"app", "-version"})
+	assert.True(f.HasMatch())
+
+	f = gendoc.ParseFlags(nil, []string{"app", "-watthewhat"})
+	assert.True(f.HasMatch())
+
+	f = gendoc.ParseFlags(nil, []string{"app"})
+	assert.False(f.HasMatch())
+}
+
+func (assert *FlagsTest) TestShowHelp() {
+	f := gendoc.ParseFlags(nil, []string{"app", "-help"})
+	assert.True(f.ShowHelp())
+
+	f = gendoc.ParseFlags(nil, []string{"app", "-version"})
+	assert.False(f.ShowHelp())
+}
+
+func (assert *FlagsTest) TestShowVersion() {
+	f := gendoc.ParseFlags(nil, []string{"app", "-version"})
+	assert.True(f.ShowVersion())
+
+	f = gendoc.ParseFlags(nil, []string{"app", "-help"})
+	assert.False(f.ShowVersion())
+}
+
+func (assert *FlagsTest) TestPrintHelp() {
+	buf := new(bytes.Buffer)
+
+	f := gendoc.ParseFlags(buf, []string{"app"})
+	f.PrintHelp()
+
+	result := buf.String()
+	assert.Contains(result, "Usage of app:\n\n")
+	assert.Contains(result, "FLAGS\n")
+	assert.Contains(result, "-help")
+	assert.Contains(result, "-version")
+}
+
+func (assert *FlagsTest) TestPrintVersion() {
+	buf := new(bytes.Buffer)
+
+	f := gendoc.ParseFlags(buf, []string{"app"})
+	f.PrintVersion()
+
+	// Normally, I'm not a fan of using constants like this in tests. However, having this break everytime the version
+	// changes is kinda poop, so I've used VERSION here.
+	assert.Equal(fmt.Sprintf("app version %s\n", gendoc.VERSION), buf.String())
+}
+
+func (assert *FlagsTest) TestInvalidFlags() {
+	buf := new(bytes.Buffer)
+
+	f := gendoc.ParseFlags(buf, []string{"app", "-wat"})
+	assert.Contains(buf.String(), "flag provided but not defined: -wat\n")
+	assert.True(f.HasMatch())
+	assert.True(f.ShowHelp())
+}


### PR DESCRIPTION
Fixes #299 

While the general use case for this tool is as a plugin, it'd be nice to be able to see the help and version details right from the command line.

As mentioned in #299 I've added support for `-help, --help, -version, --version` flags so you can quickly check the version and usage from the CLI.

![screenshot 2017-09-27 12 01 29](https://user-images.githubusercontent.com/4748863/30924065-ab068b56-a37b-11e7-8240-4fe68024cb46.png)

