### PR TITLE
Fixed #334 - Cross-package fullType and longType name resolution

### DIFF
--- a/template.go
+++ b/template.go
@@ -278,8 +278,8 @@ func parseMessageField(pf *parser.Field) *MessageField {
 		Description:  description(pf.Comment),
 		Label:        pf.Label,
 		Type:         baseName(pf.Type),
-		LongType:     strings.TrimPrefix(pf.Type, pf.Package+"."),
-		FullType:     pf.Type,
+		LongType:     longType(pf),
+		FullType:     fullType(pf.Type),
 		DefaultValue: pf.DefaultValue,
 	}
 }
@@ -315,6 +315,21 @@ func parseServiceMethod(pm *parser.ServiceMethod) *ServiceMethod {
 func baseName(name string) string {
 	parts := strings.Split(name, ".")
 	return parts[len(parts)-1]
+}
+
+func fullType(name string) string {
+	if strings.Contains(name, "..") {
+		return strings.SplitAfterN(name, "..", 2)[1]
+	}
+	return name
+}
+
+func longType(pf *parser.Field) string {
+	longType := strings.TrimPrefix(pf.Type, pf.Package+".")
+	if strings.HasPrefix(longType, ".") {
+		return strings.TrimPrefix(longType, ".")
+	}
+	return longType
 }
 
 func description(comment string) string {

--- a/template_test.go
+++ b/template_test.go
@@ -12,6 +12,7 @@ var (
 	template    *gendoc.Template
 	bookingFile *gendoc.File
 	vehicleFile *gendoc.File
+	dateFile    *gendoc.File
 )
 
 type TemplateTest struct {
@@ -30,6 +31,7 @@ func (assert *TemplateTest) SetupSuite() {
 	template = gendoc.NewTemplate(result)
 	bookingFile = template.Files[0]
 	vehicleFile = template.Files[1]
+	dateFile = template.Files[2]
 }
 
 func (assert *TemplateTest) TestTemplateProperties() {
@@ -196,6 +198,14 @@ func (assert *TemplateTest) TestExcludedComments() {
 
 	// just checking that it doesn't exclude everything
 	assert.Equal("the id of this message.", findField("id", message).Description)
+}
+
+func (assert *TemplateTest) TestCrossPackage() {
+	message := findMessage("DateTimeModifier", dateFile)
+	field := findField("date_range", message)
+
+	assert.Equal("com.example.schema.bar.DateRange", field.LongType)
+	assert.Equal("com.example.schema.bar.DateRange", field.FullType)
 }
 
 func findService(name string, f *gendoc.File) *gendoc.Service {

--- a/test/fixtures/DateRange.proto
+++ b/test/fixtures/DateRange.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+package com.example.schema.bar;
+
+/**
+ * Represents a vehicle model.
+ */
+message DateRange {
+  string startDate   = 1; // The start Date
+  string endDate      = 2; // The end Date
+}

--- a/test/fixtures/DateTimeModifier.proto
+++ b/test/fixtures/DateTimeModifier.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package com.example.schema.foo;
+
+import "test/fixtures/DateRange.proto";
+
+message DateTimeModifier {
+	// Date range is found in the "bar" package
+    bar.DateRange date_range = 1;
+}


### PR DESCRIPTION
Cross-package fullType and longType name resolution is incorrect

* Strip dot prefix from longType if present
* If double dots are present in fullType path, return the part after the double dots

