### PR TITLE
Add Regex to avoid greedy consumption of asterisks

### DIFF
--- a/examples/doc/example.docbook
+++ b/examples/doc/example.docbook
@@ -316,6 +316,423 @@
   </section>
   
   <section>
+    <title>Markdown.proto</title>
+    <para>Markdown markup messages</para><para>This file is just showing various forms of Markdown</para><para>in the comments, the output shows support for the following:</para><para>* List Item support</para><para>* **bold** text</para><para>* *italic* text</para>
+    
+    <section id="com.example.BoldMessageCpp">
+      <title>BoldMessageCpp</title>
+      <para>C++ Comments</para><para>*Italic Text1*</para><para>*Italic Text2*</para><para>*Italic Text3*</para><para>*Italic Text4*</para><para>**Bold Text**</para><para>* *Bold List Item1*</para><para>* *Bold* List Item2</para>
+      
+      <table frame="all">
+        <title><classname>BoldMessageCpp</classname> Fields</title>
+        <tgroup cols="4">
+          <colspec colwidth="*"/>
+          <colspec colwidth="*"/>
+          <colspec colwidth="0.5*"/>
+          <colspec colwidth="3*"/>
+          <thead>
+            <row>
+              <entry>Field</entry>
+              <entry>Type</entry>
+              <entry>Label</entry>
+              <entry>Description</entry>
+            </row>
+          </thead>
+          <tbody>
+            
+            <row>
+              <entry>doubleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>*Italic Text*</para></entry>
+            </row>
+            
+            <row>
+              <entry>tripleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>*Italic Text*</para></entry>
+            </row>
+            
+            <row>
+              <entry>asterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>*Italic Text*</para></entry>
+            </row>
+            
+            <row>
+              <entry>doubleAsterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>*Italic Text*</para></entry>
+            </row>
+            
+            <row>
+              <entry>noGap1</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>*Italic Text*</para></entry>
+            </row>
+            
+            <row>
+              <entry>noGap2</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>**Bold Text**</para></entry>
+            </row>
+            
+          </tbody>
+        </tgroup>
+      </table>
+      
+      
+    </section>
+    
+    <section id="com.example.BoldMessageJava">
+      <title>BoldMessageJava</title>
+      <para>Javadoc Comments with whitespace</para><para>*Italic Text1*</para><para>*Italic Text2*</para><para>*Italic Text3*</para><para>*Italic Text4*</para><para>*Italic Text5*</para><para>**Bold Text***</para>
+      
+      <table frame="all">
+        <title><classname>BoldMessageJava</classname> Fields</title>
+        <tgroup cols="4">
+          <colspec colwidth="*"/>
+          <colspec colwidth="*"/>
+          <colspec colwidth="0.5*"/>
+          <colspec colwidth="3*"/>
+          <thead>
+            <row>
+              <entry>Field</entry>
+              <entry>Type</entry>
+              <entry>Label</entry>
+              <entry>Description</entry>
+            </row>
+          </thead>
+          <tbody>
+            
+            <row>
+              <entry>doubleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>*Italic Text*</para></entry>
+            </row>
+            
+            <row>
+              <entry>tripleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>*Italic Text*</para></entry>
+            </row>
+            
+            <row>
+              <entry>asterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>*Italic Text*</para></entry>
+            </row>
+            
+            <row>
+              <entry>doubleAsterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>*Italic Text*</para></entry>
+            </row>
+            
+            <row>
+              <entry>noGapAsterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>*Italic Text*</para></entry>
+            </row>
+            
+            <row>
+              <entry>noGapDoubleAsterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>**Bold Text**</para></entry>
+            </row>
+            
+          </tbody>
+        </tgroup>
+      </table>
+      
+      
+    </section>
+    
+    <section id="com.example.ListMessageCpp">
+      <title>ListMessageCpp</title>
+      <para>C++ Comments with leading characters</para><para>* List Item1</para><para>* List Item2</para><para>* List Item3</para><para>* List Item4</para><para>* List Item5</para><para>- List Item6</para><para>- List Item7</para><para>- List Item8</para><para>- List Item9</para><para>- List Item10</para><para>Plain Text</para>
+      
+      <table frame="all">
+        <title><classname>ListMessageCpp</classname> Fields</title>
+        <tgroup cols="4">
+          <colspec colwidth="*"/>
+          <colspec colwidth="*"/>
+          <colspec colwidth="0.5*"/>
+          <colspec colwidth="3*"/>
+          <thead>
+            <row>
+              <entry>Field</entry>
+              <entry>Type</entry>
+              <entry>Label</entry>
+              <entry>Description</entry>
+            </row>
+          </thead>
+          <tbody>
+            
+            <row>
+              <entry>doubleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>* List Item</para></entry>
+            </row>
+            
+            <row>
+              <entry>tripleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>* List Item</para></entry>
+            </row>
+            
+            <row>
+              <entry>asterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>* List Item</para></entry>
+            </row>
+            
+            <row>
+              <entry>doubleAsterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>* List Item</para></entry>
+            </row>
+            
+            <row>
+              <entry>noGapDash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>- List Item</para></entry>
+            </row>
+            
+            <row>
+              <entry>noGapAsterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+          </tbody>
+        </tgroup>
+      </table>
+      
+      
+    </section>
+    
+    <section id="com.example.ListMessageJava">
+      <title>ListMessageJava</title>
+      <para>Javadoc Comments with odd indentation</para><para>* List Item1</para><para>* List Item2</para><para>* List Item3</para><para>* List Item4</para><para>* List Item5</para><para>- List Item6</para><para>- List Item7</para><para>- List Item8</para><para>- List Item9</para><para>- List Item10</para>
+      
+      <table frame="all">
+        <title><classname>ListMessageJava</classname> Fields</title>
+        <tgroup cols="4">
+          <colspec colwidth="*"/>
+          <colspec colwidth="*"/>
+          <colspec colwidth="0.5*"/>
+          <colspec colwidth="3*"/>
+          <thead>
+            <row>
+              <entry>Field</entry>
+              <entry>Type</entry>
+              <entry>Label</entry>
+              <entry>Description</entry>
+            </row>
+          </thead>
+          <tbody>
+            
+            <row>
+              <entry>doubleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>* List Item</para></entry>
+            </row>
+            
+            <row>
+              <entry>tripleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>* List Item</para></entry>
+            </row>
+            
+            <row>
+              <entry>asterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>* List Item</para></entry>
+            </row>
+            
+            <row>
+              <entry>doubleAsterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>* List Item</para></entry>
+            </row>
+            
+            <row>
+              <entry>noGapDash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>- List Item</para></entry>
+            </row>
+            
+            <row>
+              <entry>noGapAsterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+          </tbody>
+        </tgroup>
+      </table>
+      
+      
+    </section>
+    
+    <section id="com.example.PlainMessageCpp">
+      <title>PlainMessageCpp</title>
+      <para>C++ Comments with poor indentation</para><para>Plain Text1</para><para>Plain Text2</para><para>Plain Text3</para><para>Plain Text4</para><para>Plain Text5</para>
+      
+      <table frame="all">
+        <title><classname>PlainMessageCpp</classname> Fields</title>
+        <tgroup cols="4">
+          <colspec colwidth="*"/>
+          <colspec colwidth="*"/>
+          <colspec colwidth="0.5*"/>
+          <colspec colwidth="3*"/>
+          <thead>
+            <row>
+              <entry>Field</entry>
+              <entry>Type</entry>
+              <entry>Label</entry>
+              <entry>Description</entry>
+            </row>
+          </thead>
+          <tbody>
+            
+            <row>
+              <entry>doubleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+            <row>
+              <entry>tripleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+            <row>
+              <entry>asterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+            <row>
+              <entry>doubleAsterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+            <row>
+              <entry>noGap</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+          </tbody>
+        </tgroup>
+      </table>
+      
+      
+    </section>
+    
+    <section id="com.example.PlainMessageJava">
+      <title>PlainMessageJava</title>
+      <para>Javadoc Comments with poor indentation</para><para>Plain Text1</para><para>Plain Text2</para><para>Plain Text3</para><para>Plain Text4</para><para>Plain Text5</para>
+      
+      <table frame="all">
+        <title><classname>PlainMessageJava</classname> Fields</title>
+        <tgroup cols="4">
+          <colspec colwidth="*"/>
+          <colspec colwidth="*"/>
+          <colspec colwidth="0.5*"/>
+          <colspec colwidth="3*"/>
+          <thead>
+            <row>
+              <entry>Field</entry>
+              <entry>Type</entry>
+              <entry>Label</entry>
+              <entry>Description</entry>
+            </row>
+          </thead>
+          <tbody>
+            
+            <row>
+              <entry>doubleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+            <row>
+              <entry>tripleSlash</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+            <row>
+              <entry>asterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+            <row>
+              <entry>doubleAsterisk</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+            <row>
+              <entry>noGap</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry></entry>
+              <entry><para>Plain Text</para></entry>
+            </row>
+            
+          </tbody>
+        </tgroup>
+      </table>
+      
+      
+    </section>
+    
+    
+
+    
+
+    
+  </section>
+  
+  <section>
     <title>Vehicle.proto</title>
     <para>Messages describing manufacturers / vehicles.</para>
     

--- a/examples/doc/example.html
+++ b/examples/doc/example.html
@@ -221,6 +221,41 @@
         
           
           <li>
+            <a href="#Markdown.proto">Markdown.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#com.example.BoldMessageCpp"><span class="badge">M</span>BoldMessageCpp</a>
+                </li>
+              
+                <li>
+                  <a href="#com.example.BoldMessageJava"><span class="badge">M</span>BoldMessageJava</a>
+                </li>
+              
+                <li>
+                  <a href="#com.example.ListMessageCpp"><span class="badge">M</span>ListMessageCpp</a>
+                </li>
+              
+                <li>
+                  <a href="#com.example.ListMessageJava"><span class="badge">M</span>ListMessageJava</a>
+                </li>
+              
+                <li>
+                  <a href="#com.example.PlainMessageCpp"><span class="badge">M</span>PlainMessageCpp</a>
+                </li>
+              
+                <li>
+                  <a href="#com.example.PlainMessageJava"><span class="badge">M</span>PlainMessageJava</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
             <a href="#Vehicle.proto">Vehicle.proto</a>
             <ul>
               
@@ -501,6 +536,354 @@
                   <td><a href="#com.example.Address">Address</a></td>
                   <td>repeated</td>
                   <td><p>Customer mail addresses, primary first. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+        
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="Markdown.proto">Markdown.proto</h2><a href="#title">Top</a>
+      </div>
+      <p>Markdown markup messages</p><p>This file is just showing various forms of Markdown</p><p>in the comments, the output shows support for the following:</p><p>* List Item support</p><p>* **bold** text</p><p>* *italic* text</p>
+
+      
+        <h3 id="com.example.BoldMessageCpp">BoldMessageCpp</h3>
+        <p>C++ Comments</p><p>*Italic Text1*</p><p>*Italic Text2*</p><p>*Italic Text3*</p><p>*Italic Text4*</p><p>**Bold Text**</p><p>* *Bold List Item1*</p><p>* *Bold* List Item2</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>doubleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>*Italic Text* </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tripleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>*Italic Text* </p></td>
+                </tr>
+              
+                <tr>
+                  <td>asterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>*Italic Text* </p></td>
+                </tr>
+              
+                <tr>
+                  <td>doubleAsterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>*Italic Text* </p></td>
+                </tr>
+              
+                <tr>
+                  <td>noGap1</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>*Italic Text* </p></td>
+                </tr>
+              
+                <tr>
+                  <td>noGap2</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>**Bold Text** </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+        
+
+        
+      
+        <h3 id="com.example.BoldMessageJava">BoldMessageJava</h3>
+        <p>Javadoc Comments with whitespace</p><p>*Italic Text1*</p><p>*Italic Text2*</p><p>*Italic Text3*</p><p>*Italic Text4*</p><p>*Italic Text5*</p><p>**Bold Text***</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>doubleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>*Italic Text* </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tripleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>*Italic Text* </p></td>
+                </tr>
+              
+                <tr>
+                  <td>asterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>*Italic Text* </p></td>
+                </tr>
+              
+                <tr>
+                  <td>doubleAsterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>*Italic Text* </p></td>
+                </tr>
+              
+                <tr>
+                  <td>noGapAsterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>*Italic Text* </p></td>
+                </tr>
+              
+                <tr>
+                  <td>noGapDoubleAsterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>**Bold Text** </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+        
+
+        
+      
+        <h3 id="com.example.ListMessageCpp">ListMessageCpp</h3>
+        <p>C++ Comments with leading characters</p><p>* List Item1</p><p>* List Item2</p><p>* List Item3</p><p>* List Item4</p><p>* List Item5</p><p>- List Item6</p><p>- List Item7</p><p>- List Item8</p><p>- List Item9</p><p>- List Item10</p><p>Plain Text</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>doubleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>* List Item </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tripleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>* List Item </p></td>
+                </tr>
+              
+                <tr>
+                  <td>asterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>* List Item </p></td>
+                </tr>
+              
+                <tr>
+                  <td>doubleAsterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>* List Item </p></td>
+                </tr>
+              
+                <tr>
+                  <td>noGapDash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>- List Item </p></td>
+                </tr>
+              
+                <tr>
+                  <td>noGapAsterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+        
+
+        
+      
+        <h3 id="com.example.ListMessageJava">ListMessageJava</h3>
+        <p>Javadoc Comments with odd indentation</p><p>* List Item1</p><p>* List Item2</p><p>* List Item3</p><p>* List Item4</p><p>* List Item5</p><p>- List Item6</p><p>- List Item7</p><p>- List Item8</p><p>- List Item9</p><p>- List Item10</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>doubleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>* List Item </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tripleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>* List Item </p></td>
+                </tr>
+              
+                <tr>
+                  <td>asterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>* List Item </p></td>
+                </tr>
+              
+                <tr>
+                  <td>doubleAsterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>* List Item </p></td>
+                </tr>
+              
+                <tr>
+                  <td>noGapDash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>- List Item </p></td>
+                </tr>
+              
+                <tr>
+                  <td>noGapAsterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+        
+
+        
+      
+        <h3 id="com.example.PlainMessageCpp">PlainMessageCpp</h3>
+        <p>C++ Comments with poor indentation</p><p>Plain Text1</p><p>Plain Text2</p><p>Plain Text3</p><p>Plain Text4</p><p>Plain Text5</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>doubleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tripleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+                <tr>
+                  <td>asterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+                <tr>
+                  <td>doubleAsterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+                <tr>
+                  <td>noGap</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+        
+
+        
+      
+        <h3 id="com.example.PlainMessageJava">PlainMessageJava</h3>
+        <p>Javadoc Comments with poor indentation</p><p>Plain Text1</p><p>Plain Text2</p><p>Plain Text3</p><p>Plain Text4</p><p>Plain Text5</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>doubleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+                <tr>
+                  <td>tripleSlash</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+                <tr>
+                  <td>asterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+                <tr>
+                  <td>doubleAsterisk</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
+                </tr>
+              
+                <tr>
+                  <td>noGap</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td></td>
+                  <td><p>Plain Text </p></td>
                 </tr>
               
             </tbody>

--- a/examples/doc/example.json
+++ b/examples/doc/example.json
@@ -27,9 +27,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "customer_id",
@@ -38,9 +36,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "status",
@@ -49,9 +45,7 @@
               "type": "BookingStatus",
               "longType": "BookingStatus",
               "fullType": "com.example.BookingStatus",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "confirmation_sent",
@@ -60,9 +54,7 @@
               "type": "bool",
               "longType": "bool",
               "fullType": "bool",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "payment_received",
@@ -71,9 +63,7 @@
               "type": "bool",
               "longType": "bool",
               "fullType": "bool",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -93,9 +83,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "description",
@@ -104,9 +92,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -169,9 +155,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "address_line_2",
@@ -180,9 +164,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "address_line_3",
@@ -191,9 +173,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "town",
@@ -202,9 +182,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "county",
@@ -213,9 +191,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "country",
@@ -224,9 +200,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -246,9 +220,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "first_name",
@@ -257,9 +229,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "last_name",
@@ -268,9 +238,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "details",
@@ -279,9 +247,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "email_address",
@@ -290,9 +256,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "phone_number",
@@ -301,9 +265,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "mail_addresses",
@@ -312,9 +274,7 @@
               "type": "Address",
               "longType": "Address",
               "fullType": "com.example.Address",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         }
@@ -348,9 +308,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "tripleSlash",
@@ -359,9 +317,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "asterisk",
@@ -370,9 +326,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "doubleAsterisk",
@@ -381,9 +335,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "noGap1",
@@ -392,9 +344,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "noGap2",
@@ -403,9 +353,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -425,9 +373,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "tripleSlash",
@@ -436,9 +382,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "asterisk",
@@ -447,9 +391,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "doubleAsterisk",
@@ -458,9 +400,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "noGapAsterisk",
@@ -469,9 +409,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "noGapDoubleAsterisk",
@@ -480,9 +418,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -502,9 +438,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "tripleSlash",
@@ -513,9 +447,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "asterisk",
@@ -524,9 +456,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "doubleAsterisk",
@@ -535,9 +465,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "noGapDash",
@@ -546,9 +474,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "noGapAsterisk",
@@ -557,9 +483,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -579,9 +503,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "tripleSlash",
@@ -590,9 +512,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "asterisk",
@@ -601,9 +521,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "doubleAsterisk",
@@ -612,9 +530,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "noGapDash",
@@ -623,9 +539,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "noGapAsterisk",
@@ -634,9 +548,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -656,9 +568,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "tripleSlash",
@@ -667,9 +577,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "asterisk",
@@ -678,9 +586,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "doubleAsterisk",
@@ -689,9 +595,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "noGap",
@@ -700,9 +604,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -722,9 +624,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "tripleSlash",
@@ -733,9 +633,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "asterisk",
@@ -744,9 +642,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "doubleAsterisk",
@@ -755,9 +651,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "noGap",
@@ -766,9 +660,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         }
@@ -837,9 +729,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "code",
@@ -848,9 +738,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "details",
@@ -859,9 +747,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "category",
@@ -870,9 +756,7 @@
               "type": "Category",
               "longType": "Manufacturer.Category",
               "fullType": "com.example.Manufacturer.Category",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -892,9 +776,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "model_code",
@@ -903,9 +785,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "model_name",
@@ -914,9 +794,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "daily_hire_rate_dollars",
@@ -925,9 +803,7 @@
               "type": "sint32",
               "longType": "sint32",
               "fullType": "sint32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "daily_hire_rate_cents",
@@ -936,9 +812,7 @@
               "type": "sint32",
               "longType": "sint32",
               "fullType": "sint32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -977,9 +851,7 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "model",
@@ -988,9 +860,7 @@
               "type": "Model",
               "longType": "Model",
               "fullType": "com.example.Model",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "reg_number",
@@ -999,9 +869,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "mileage",
@@ -1010,9 +878,7 @@
               "type": "sint32",
               "longType": "sint32",
               "fullType": "sint32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "category",
@@ -1021,9 +887,7 @@
               "type": "Category",
               "longType": "Vehicle.Category",
               "fullType": "com.example.Vehicle.Category",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "daily_hire_rate_dollars",
@@ -1032,9 +896,7 @@
               "type": "sint32",
               "longType": "sint32",
               "fullType": "sint32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "daily_hire_rate_cents",
@@ -1043,9 +905,7 @@
               "type": "sint32",
               "longType": "sint32",
               "fullType": "sint32",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         },
@@ -1065,9 +925,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             },
             {
               "name": "description",
@@ -1076,9 +934,7 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": "",
-              "oneOf": "",
-              "oneOfDesc": ""
+              "defaultValue": ""
             }
           ]
         }

--- a/examples/doc/example.json
+++ b/examples/doc/example.json
@@ -27,7 +27,9 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "customer_id",
@@ -36,7 +38,9 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "status",
@@ -45,7 +49,9 @@
               "type": "BookingStatus",
               "longType": "BookingStatus",
               "fullType": "com.example.BookingStatus",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "confirmation_sent",
@@ -54,7 +60,9 @@
               "type": "bool",
               "longType": "bool",
               "fullType": "bool",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "payment_received",
@@ -63,7 +71,9 @@
               "type": "bool",
               "longType": "bool",
               "fullType": "bool",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             }
           ]
         },
@@ -83,7 +93,9 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "description",
@@ -92,7 +104,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             }
           ]
         },
@@ -155,7 +169,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "address_line_2",
@@ -164,7 +180,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "address_line_3",
@@ -173,7 +191,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "town",
@@ -182,7 +202,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "county",
@@ -191,7 +213,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "country",
@@ -200,7 +224,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             }
           ]
         },
@@ -220,7 +246,9 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "first_name",
@@ -229,7 +257,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "last_name",
@@ -238,7 +268,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "details",
@@ -247,7 +279,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "email_address",
@@ -256,7 +290,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "phone_number",
@@ -265,7 +301,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "mail_addresses",
@@ -274,7 +312,463 @@
               "type": "Address",
               "longType": "Address",
               "fullType": "com.example.Address",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
+      "name": "Markdown.proto",
+      "description": "Markdown markup messages\n\nThis file is just showing various forms of Markdown\nin the comments, the output shows support for the following:\n\n* List Item support\n* **bold** text\n* *italic* text",
+      "package": "com.example",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "BoldMessageCpp",
+          "longName": "BoldMessageCpp",
+          "fullName": "com.example.BoldMessageCpp",
+          "description": "C++ Comments\n\n*Italic Text1*\n*Italic Text2*\n*Italic Text3*\n*Italic Text4*\n\n**Bold Text**\n\n* *Bold List Item1*\n* *Bold* List Item2",
+          "hasExtensions": false,
+          "hasFields": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "doubleSlash",
+              "description": "*Italic Text*",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "tripleSlash",
+              "description": "*Italic Text*",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "asterisk",
+              "description": "*Italic Text*",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "doubleAsterisk",
+              "description": "*Italic Text*",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "noGap1",
+              "description": "*Italic Text*",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "noGap2",
+              "description": "**Bold Text**",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            }
+          ]
+        },
+        {
+          "name": "BoldMessageJava",
+          "longName": "BoldMessageJava",
+          "fullName": "com.example.BoldMessageJava",
+          "description": "Javadoc Comments with whitespace\n\n*Italic Text1*\n*Italic Text2*\n*Italic Text3*\n*Italic Text4*\n*Italic Text5*\n\n**Bold Text***",
+          "hasExtensions": false,
+          "hasFields": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "doubleSlash",
+              "description": "*Italic Text*",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "tripleSlash",
+              "description": "*Italic Text*",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "asterisk",
+              "description": "*Italic Text*",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "doubleAsterisk",
+              "description": "*Italic Text*",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "noGapAsterisk",
+              "description": "*Italic Text*",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "noGapDoubleAsterisk",
+              "description": "**Bold Text**",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            }
+          ]
+        },
+        {
+          "name": "ListMessageCpp",
+          "longName": "ListMessageCpp",
+          "fullName": "com.example.ListMessageCpp",
+          "description": "C++ Comments with leading characters\n\n* List Item1\n* List Item2\n* List Item3\n* List Item4\n* List Item5\n\n- List Item6\n- List Item7\n- List Item8\n- List Item9\n- List Item10\n\nPlain Text",
+          "hasExtensions": false,
+          "hasFields": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "doubleSlash",
+              "description": "* List Item",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "tripleSlash",
+              "description": "* List Item",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "asterisk",
+              "description": "* List Item",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "doubleAsterisk",
+              "description": "* List Item",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "noGapDash",
+              "description": "- List Item",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "noGapAsterisk",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            }
+          ]
+        },
+        {
+          "name": "ListMessageJava",
+          "longName": "ListMessageJava",
+          "fullName": "com.example.ListMessageJava",
+          "description": "Javadoc Comments with odd indentation\n\n* List Item1\n* List Item2\n* List Item3\n* List Item4\n* List Item5\n\n- List Item6\n- List Item7\n- List Item8\n- List Item9\n- List Item10",
+          "hasExtensions": false,
+          "hasFields": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "doubleSlash",
+              "description": "* List Item",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "tripleSlash",
+              "description": "* List Item",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "asterisk",
+              "description": "* List Item",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "doubleAsterisk",
+              "description": "* List Item",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "noGapDash",
+              "description": "- List Item",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "noGapAsterisk",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            }
+          ]
+        },
+        {
+          "name": "PlainMessageCpp",
+          "longName": "PlainMessageCpp",
+          "fullName": "com.example.PlainMessageCpp",
+          "description": "C++ Comments with poor indentation\n\nPlain Text1\nPlain Text2\nPlain Text3\nPlain Text4\nPlain Text5",
+          "hasExtensions": false,
+          "hasFields": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "doubleSlash",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "tripleSlash",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "asterisk",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "doubleAsterisk",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "noGap",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            }
+          ]
+        },
+        {
+          "name": "PlainMessageJava",
+          "longName": "PlainMessageJava",
+          "fullName": "com.example.PlainMessageJava",
+          "description": "Javadoc Comments with poor indentation\n\nPlain Text1\nPlain Text2\nPlain Text3\nPlain Text4\nPlain Text5",
+          "hasExtensions": false,
+          "hasFields": true,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "doubleSlash",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "tripleSlash",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "asterisk",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "doubleAsterisk",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
+            },
+            {
+              "name": "noGap",
+              "description": "Plain Text",
+              "label": "",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             }
           ]
         }
@@ -343,7 +837,9 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "code",
@@ -352,7 +848,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "details",
@@ -361,7 +859,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "category",
@@ -370,7 +870,9 @@
               "type": "Category",
               "longType": "Manufacturer.Category",
               "fullType": "com.example.Manufacturer.Category",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             }
           ]
         },
@@ -390,7 +892,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "model_code",
@@ -399,7 +903,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "model_name",
@@ -408,7 +914,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "daily_hire_rate_dollars",
@@ -417,7 +925,9 @@
               "type": "sint32",
               "longType": "sint32",
               "fullType": "sint32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "daily_hire_rate_cents",
@@ -426,7 +936,9 @@
               "type": "sint32",
               "longType": "sint32",
               "fullType": "sint32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             }
           ]
         },
@@ -465,7 +977,9 @@
               "type": "int32",
               "longType": "int32",
               "fullType": "int32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "model",
@@ -474,7 +988,9 @@
               "type": "Model",
               "longType": "Model",
               "fullType": "com.example.Model",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "reg_number",
@@ -483,7 +999,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "mileage",
@@ -492,7 +1010,9 @@
               "type": "sint32",
               "longType": "sint32",
               "fullType": "sint32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "category",
@@ -501,7 +1021,9 @@
               "type": "Category",
               "longType": "Vehicle.Category",
               "fullType": "com.example.Vehicle.Category",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "daily_hire_rate_dollars",
@@ -510,7 +1032,9 @@
               "type": "sint32",
               "longType": "sint32",
               "fullType": "sint32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "daily_hire_rate_cents",
@@ -519,7 +1043,9 @@
               "type": "sint32",
               "longType": "sint32",
               "fullType": "sint32",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             }
           ]
         },
@@ -539,7 +1065,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             },
             {
               "name": "description",
@@ -548,7 +1076,9 @@
               "type": "string",
               "longType": "string",
               "fullType": "string",
-              "defaultValue": ""
+              "defaultValue": "",
+              "oneOf": "",
+              "oneOfDesc": ""
             }
           ]
         }

--- a/examples/doc/example.md
+++ b/examples/doc/example.md
@@ -21,6 +21,18 @@
   
   
 
+- [Markdown.proto](#Markdown.proto)
+    - [BoldMessageCpp](#com.example.BoldMessageCpp)
+    - [BoldMessageJava](#com.example.BoldMessageJava)
+    - [ListMessageCpp](#com.example.ListMessageCpp)
+    - [ListMessageJava](#com.example.ListMessageJava)
+    - [PlainMessageCpp](#com.example.PlainMessageCpp)
+    - [PlainMessageJava](#com.example.PlainMessageJava)
+  
+  
+  
+  
+
 - [Vehicle.proto](#Vehicle.proto)
     - [Manufacturer](#com.example.Manufacturer)
     - [Model](#com.example.Model)
@@ -155,6 +167,203 @@ Represents a customer.
 | email_address | [string](#string) | optional | Customer e-mail address. |
 | phone_number | [string](#string) | repeated | Customer phone numbers, primary first. |
 | mail_addresses | [Address](#com.example.Address) | repeated | Customer mail addresses, primary first. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="Markdown.proto"/>
+<p align="right"><a href="#top">Top</a></p>
+
+## Markdown.proto
+Markdown markup messages
+
+This file is just showing various forms of Markdown
+in the comments, the output shows support for the following:
+
+* List Item support
+* **bold** text
+* *italic* text
+
+
+<a name="com.example.BoldMessageCpp"/>
+
+### BoldMessageCpp
+C&#43;&#43; Comments
+
+*Italic Text1*
+*Italic Text2*
+*Italic Text3*
+*Italic Text4*
+
+**Bold Text**
+
+* *Bold List Item1*
+* *Bold* List Item2
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| doubleSlash | [int32](#int32) |  | *Italic Text* |
+| tripleSlash | [int32](#int32) |  | *Italic Text* |
+| asterisk | [int32](#int32) |  | *Italic Text* |
+| doubleAsterisk | [int32](#int32) |  | *Italic Text* |
+| noGap1 | [int32](#int32) |  | *Italic Text* |
+| noGap2 | [int32](#int32) |  | **Bold Text** |
+
+
+
+
+
+
+<a name="com.example.BoldMessageJava"/>
+
+### BoldMessageJava
+Javadoc Comments with whitespace
+
+*Italic Text1*
+*Italic Text2*
+*Italic Text3*
+*Italic Text4*
+*Italic Text5*
+
+**Bold Text***
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| doubleSlash | [int32](#int32) |  | *Italic Text* |
+| tripleSlash | [int32](#int32) |  | *Italic Text* |
+| asterisk | [int32](#int32) |  | *Italic Text* |
+| doubleAsterisk | [int32](#int32) |  | *Italic Text* |
+| noGapAsterisk | [int32](#int32) |  | *Italic Text* |
+| noGapDoubleAsterisk | [int32](#int32) |  | **Bold Text** |
+
+
+
+
+
+
+<a name="com.example.ListMessageCpp"/>
+
+### ListMessageCpp
+C&#43;&#43; Comments with leading characters
+
+* List Item1
+* List Item2
+* List Item3
+* List Item4
+* List Item5
+
+- List Item6
+- List Item7
+- List Item8
+- List Item9
+- List Item10
+
+Plain Text
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| doubleSlash | [int32](#int32) |  | * List Item |
+| tripleSlash | [int32](#int32) |  | * List Item |
+| asterisk | [int32](#int32) |  | * List Item |
+| doubleAsterisk | [int32](#int32) |  | * List Item |
+| noGapDash | [int32](#int32) |  | - List Item |
+| noGapAsterisk | [int32](#int32) |  | Plain Text |
+
+
+
+
+
+
+<a name="com.example.ListMessageJava"/>
+
+### ListMessageJava
+Javadoc Comments with odd indentation
+
+* List Item1
+* List Item2
+* List Item3
+* List Item4
+* List Item5
+
+- List Item6
+- List Item7
+- List Item8
+- List Item9
+- List Item10
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| doubleSlash | [int32](#int32) |  | * List Item |
+| tripleSlash | [int32](#int32) |  | * List Item |
+| asterisk | [int32](#int32) |  | * List Item |
+| doubleAsterisk | [int32](#int32) |  | * List Item |
+| noGapDash | [int32](#int32) |  | - List Item |
+| noGapAsterisk | [int32](#int32) |  | Plain Text |
+
+
+
+
+
+
+<a name="com.example.PlainMessageCpp"/>
+
+### PlainMessageCpp
+C&#43;&#43; Comments with poor indentation
+
+Plain Text1
+Plain Text2
+Plain Text3
+Plain Text4
+Plain Text5
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| doubleSlash | [int32](#int32) |  | Plain Text |
+| tripleSlash | [int32](#int32) |  | Plain Text |
+| asterisk | [int32](#int32) |  | Plain Text |
+| doubleAsterisk | [int32](#int32) |  | Plain Text |
+| noGap | [int32](#int32) |  | Plain Text |
+
+
+
+
+
+
+<a name="com.example.PlainMessageJava"/>
+
+### PlainMessageJava
+Javadoc Comments with poor indentation
+
+Plain Text1
+Plain Text2
+Plain Text3
+Plain Text4
+Plain Text5
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| doubleSlash | [int32](#int32) |  | Plain Text |
+| tripleSlash | [int32](#int32) |  | Plain Text |
+| asterisk | [int32](#int32) |  | Plain Text |
+| doubleAsterisk | [int32](#int32) |  | Plain Text |
+| noGap | [int32](#int32) |  | Plain Text |
 
 
 

--- a/examples/doc/example.txt
+++ b/examples/doc/example.txt
@@ -107,6 +107,147 @@ Represents a customer.
 
 
 
+== Markdown.proto
+
+
+
+=== BoldMessageCpp
+C++ Comments *Italic Text1* *Italic Text2* *Italic Text3* *Italic Text4* **Bold Text** * *Bold List Item1* * *Bold* List Item2
+
+
+|===========================================
+|*Field* |*Type* |*Label* |*Description*
+
+|doubleSlash | <<int32,int32>> | |*Italic Text*
+
+|tripleSlash | <<int32,int32>> | |*Italic Text*
+
+|asterisk | <<int32,int32>> | |*Italic Text*
+
+|doubleAsterisk | <<int32,int32>> | |*Italic Text*
+
+|noGap1 | <<int32,int32>> | |*Italic Text*
+
+|noGap2 | <<int32,int32>> | |**Bold Text**
+
+|===========================================
+
+
+
+=== BoldMessageJava
+Javadoc Comments with whitespace *Italic Text1* *Italic Text2* *Italic Text3* *Italic Text4* *Italic Text5* **Bold Text***
+
+
+|===========================================
+|*Field* |*Type* |*Label* |*Description*
+
+|doubleSlash | <<int32,int32>> | |*Italic Text*
+
+|tripleSlash | <<int32,int32>> | |*Italic Text*
+
+|asterisk | <<int32,int32>> | |*Italic Text*
+
+|doubleAsterisk | <<int32,int32>> | |*Italic Text*
+
+|noGapAsterisk | <<int32,int32>> | |*Italic Text*
+
+|noGapDoubleAsterisk | <<int32,int32>> | |**Bold Text**
+
+|===========================================
+
+
+
+=== ListMessageCpp
+C++ Comments with leading characters * List Item1 * List Item2 * List Item3 * List Item4 * List Item5 - List Item6 - List Item7 - List Item8 - List Item9 - List Item10 Plain Text
+
+
+|===========================================
+|*Field* |*Type* |*Label* |*Description*
+
+|doubleSlash | <<int32,int32>> | |* List Item
+
+|tripleSlash | <<int32,int32>> | |* List Item
+
+|asterisk | <<int32,int32>> | |* List Item
+
+|doubleAsterisk | <<int32,int32>> | |* List Item
+
+|noGapDash | <<int32,int32>> | |- List Item
+
+|noGapAsterisk | <<int32,int32>> | |Plain Text
+
+|===========================================
+
+
+
+=== ListMessageJava
+Javadoc Comments with odd indentation * List Item1 * List Item2 * List Item3 * List Item4 * List Item5 - List Item6 - List Item7 - List Item8 - List Item9 - List Item10
+
+
+|===========================================
+|*Field* |*Type* |*Label* |*Description*
+
+|doubleSlash | <<int32,int32>> | |* List Item
+
+|tripleSlash | <<int32,int32>> | |* List Item
+
+|asterisk | <<int32,int32>> | |* List Item
+
+|doubleAsterisk | <<int32,int32>> | |* List Item
+
+|noGapDash | <<int32,int32>> | |- List Item
+
+|noGapAsterisk | <<int32,int32>> | |Plain Text
+
+|===========================================
+
+
+
+=== PlainMessageCpp
+C++ Comments with poor indentation Plain Text1 Plain Text2 Plain Text3 Plain Text4 Plain Text5
+
+
+|===========================================
+|*Field* |*Type* |*Label* |*Description*
+
+|doubleSlash | <<int32,int32>> | |Plain Text
+
+|tripleSlash | <<int32,int32>> | |Plain Text
+
+|asterisk | <<int32,int32>> | |Plain Text
+
+|doubleAsterisk | <<int32,int32>> | |Plain Text
+
+|noGap | <<int32,int32>> | |Plain Text
+
+|===========================================
+
+
+
+=== PlainMessageJava
+Javadoc Comments with poor indentation Plain Text1 Plain Text2 Plain Text3 Plain Text4 Plain Text5
+
+
+|===========================================
+|*Field* |*Type* |*Label* |*Description*
+
+|doubleSlash | <<int32,int32>> | |Plain Text
+
+|tripleSlash | <<int32,int32>> | |Plain Text
+
+|asterisk | <<int32,int32>> | |Plain Text
+
+|doubleAsterisk | <<int32,int32>> | |Plain Text
+
+|noGap | <<int32,int32>> | |Plain Text
+
+|===========================================
+
+
+
+
+
+
 == Vehicle.proto
 
 

--- a/examples/proto/Markdown.proto
+++ b/examples/proto/Markdown.proto
@@ -1,0 +1,150 @@
+/**
+ * Markdown markup messages
+ *
+ * This file is just showing various forms of Markdown 
+ * in the comments, the output shows support for the following:
+ * 
+ * * List Item support
+ * * **bold** text
+ * * *italic* text
+ * 
+ */
+syntax = "proto3";
+
+package com.example;
+
+
+
+/**********************
+ *
+ * Javadoc Comments with odd indentation     *
+ * 
+ * * List Item1       *
+* * List Item2       *
+ ** * List Item3      *
+  ** * List Item4     *
+   **   * List Item5  **
+ *
+ *- List Item6       
+ * - List Item7       
+ ** - List Item8      
+  ** - List Item9     
+   **   - List Item10  
+ ***********************/
+message ListMessageJava {
+  int32 doubleSlash     = 1; // * List Item
+  int32 tripleSlash     = 2; /// * List Item
+  int32 asterisk        = 3; /* * List Item */
+  int32 doubleAsterisk  = 4; /** * List Item */
+  int32 noGapDash       = 5; /*- List Item */
+  int32 noGapAsterisk   = 6; /** Plain Text*/
+}
+
+/////////////////////////
+//
+// C++ Comments with leading characters   //
+// 
+// * List Item1      /
+/// * List Item2      //
+/// * List Item3       /
+///** * List Item4     //
+//   * List Item5  //
+//   
+//- List Item6      
+// - List Item7      
+/// - List Item8    
+///** - List Item9     
+//   - List Item10 
+//   
+//* Plain Text       ///
+/////////////////////////
+message ListMessageCpp {
+  int32 doubleSlash     = 1; // * List Item
+  int32 tripleSlash     = 2; /// * List Item
+  int32 asterisk        = 3; /* * List Item */
+  int32 doubleAsterisk  = 4; /** * List Item */
+  int32 noGapDash       = 5; //- List Item
+  int32 noGapAsterisk   = 6; //* Plain Text
+}
+
+
+/**********************
+ *
+ * Javadoc Comments with whitespace    *
+ * 
+ * *Italic Text1*       *
+ * *Italic Text2*       *
+ ** *Italic Text3*      *
+  ** *Italic Text4*     *
+   **   *Italic Text5*  **
+ *
+ ***Bold Text***
+ ***********************/
+message BoldMessageJava {
+  int32 doubleSlash         = 1; // *Italic Text*
+  int32 tripleSlash         = 2; /// *Italic Text*
+  int32 asterisk            = 3; /* *Italic Text* */
+  int32 doubleAsterisk      = 4; /** *Italic Text* */
+  int32 noGapAsterisk       = 5; /**Italic Text**/
+  int32 noGapDoubleAsterisk = 6; /***Bold Text***/
+}
+
+/////////////////////////
+//
+// C++ Comments     //
+// 
+// *Italic Text1*      /
+/// *Italic Text2*      //
+//   *Italic Text3*  //
+///* *Italic Text4*      /
+//
+//**Bold Text**
+//   
+/// * *Bold List Item1*     //
+// * *Bold* List Item2
+/////////////////////////
+message BoldMessageCpp {
+  int32 doubleSlash     = 1; // *Italic Text*
+  int32 tripleSlash     = 2; /// *Italic Text*
+  int32 asterisk        = 3; /* *Italic Text* */
+  int32 doubleAsterisk  = 4; /** *Italic Text* */
+  int32 noGap1          = 5; //*Italic Text*
+  int32 noGap2          = 6; //**Bold Text**
+}
+
+
+/**********************
+*
+ * Javadoc Comments with poor indentation    *
+  *  
+ * Plain Text1       *
+ *Plain Text2      *
+ ** Plain Text3      *
+  ** Plain Text4     
+   **   Plain Text5  **
+ ***********************/
+message PlainMessageJava {
+  int32 doubleSlash     = 1; // Plain Text //
+  int32 tripleSlash     = 2; /// Plain Text ///
+  int32 asterisk        = 3; /* Plain Text */
+  int32 doubleAsterisk  = 4; /** Plain Text **/
+  int32 noGap           = 5; /*Plain Text*/
+}
+
+///////////////////////////////////////////
+//
+// C++ Comments with poor indentation    //
+//
+// Plain Text1      /
+/// Plain Text2      //
+//Plain Text3      /
+/// Plain Text4     //
+ //   Plain Text5 
+/////////////////////////
+message PlainMessageCpp {
+  int32 doubleSlash     = 1; // Plain Text
+  int32 tripleSlash     = 2; /// Plain Text
+  int32 asterisk        = 3; /* Plain Text */
+  int32 doubleAsterisk  = 4; /** Plain Text */
+  int32 noGap           = 5; //Plain Text
+}

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -48,6 +48,18 @@ func (ce *commentExtractor) commentForPath(path string) string {
 	return scrubComment(ce.comments[path])
 }
 
+//
+// SourceCodeInfo_Location already strips out standard comment markers.
+// This function is used to remove additional comment decorations
+// at the beginning and end of each line.
+// 
+// 1) Remove Line Start plus any / or * followed by line end 
+//    that is a complete comment decoration line
+// 2) Remove Line Start plus any / or * followed by whitepace 
+//    that is a comment decoration at start of line
+// 3) Remove Whitespace plus any / or * followed by line end 
+//    that is a comment decoration at end of line
+//
 func scrubComment(s string) string {
 	var rePrefix = regexp.MustCompile(`^/*(\**|/*)(\s+|$)`)
 	var reSuffix = regexp.MustCompile(`\s+(\**|/*)$`)

--- a/parser/comments.go
+++ b/parser/comments.go
@@ -4,6 +4,7 @@ import (
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"strconv"
 	"strings"
+	"regexp"
 )
 
 type commentContainer interface {
@@ -48,10 +49,15 @@ func (ce *commentExtractor) commentForPath(path string) string {
 }
 
 func scrubComment(s string) string {
+	var rePrefix = regexp.MustCompile(`^/*(\**|/*)(\s+|$)`)
+	var reSuffix = regexp.MustCompile(`\s+(\**|/*)$`)
 	lines := strings.Split(s, "\n")
 
 	for idx, line := range lines {
-		lines[idx] = strings.Trim(line, " /\n*")
+		line = strings.TrimRight(line, " /\n")
+		line = rePrefix.ReplaceAllString(line, "")
+		line = reSuffix.ReplaceAllString(line, "")
+		lines[idx] = strings.TrimLeft(line, " \n")
 	}
 
 	return strings.Trim(strings.Join(lines, "\n"), "\n")


### PR DESCRIPTION
This PR improves markdown output by restricting the removal of comment decorators as follows:

 - Remove  Line Start plus any / or * followed by line end - i.e. a complete decoration line
 - Remove  Line Start plus any / or * followed by whitespace  - i.e. a decoration at start of line
 - Remove  whitespace plus any / or * followed by line end  - i.e. a decoration at end of line

Some people, when confronted with a problem, think "I know, I'll use regular expressions." Now they have two problems.