### PR TITLE
allow disable sorting

### DIFF
--- a/template.go
+++ b/template.go
@@ -6,6 +6,7 @@ import (
 
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 )
@@ -62,10 +63,13 @@ func NewTemplate(descs []*protokit.FileDescriptor) *Template {
 			file.Services = append(file.Services, parseService(s))
 		}
 
-		sort.Sort(file.Enums)
-		sort.Sort(file.Extensions)
-		sort.Sort(file.Messages)
-		sort.Sort(file.Services)
+		if os.Getenv("DISABLE_SORT") != "1" {
+			//fmt.Printf("sort disabled\n")
+			sort.Sort(file.Enums)
+			sort.Sort(file.Extensions)
+			sort.Sort(file.Messages)
+			sort.Sort(file.Services)
+		}
 
 		files = append(files, file)
 	}


### PR DESCRIPTION
I'd like to be able to disable sorting of messages. I know os.Getenv probably isn't the best way to pass this flag, so tell me how it should be done and I'll fix it