### PR TITLE
Use String() for comparing Regexp objects in CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased](https://github.com/pseudomuto/protoc-gen-doc/compare/v1.1.0...master)
 
+### Fixed
+
+* CI issue related to Regexp comparison on Golang master
+
 ## [v1.1.0](https://github.com/pseudomuto/protoc-gen-doc/compare/v1.0.0...v1.1.0) - March 13, 2018
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ fixtures/fileset.pb: fixtures/*.proto fixtures/generate.go
 	@cd fixtures && go generate
 
 test: fixtures/fileset.pb resources.go
-	@go test -cover ./ ./cmd/...
+	@go test -cover -race ./ ./cmd/...
 
 bench:
 	@go test -bench=.

--- a/plugin_test.go
+++ b/plugin_test.go
@@ -65,8 +65,8 @@ func (assert *PluginTest) TestParseOptionsForExcludePatterns() {
 	assert.Equal(2, len(options.ExcludePatterns))
 	pattern0, _ := regexp.Compile("google/*")
 	pattern1, _ := regexp.Compile("notgoogle/*")
-	assert.Equal(pattern0, options.ExcludePatterns[0])
-	assert.Equal(pattern1, options.ExcludePatterns[1])
+	assert.Equal(pattern0.String(), options.ExcludePatterns[0].String())
+	assert.Equal(pattern1.String(), options.ExcludePatterns[1].String())
 }
 
 func (assert *PluginTest) TestParseOptionsWithInvalidValues() {


### PR DESCRIPTION
There appears to be some changes on the golang master branch that change they way Regexp objects can be compared. Specifically, my guess would be the that it was introduced [here](https://github.com/golang/go/commit/7dbf9d43f5a62a604ab3e6ceb1ee7ac4f3a80d80).

I've updated to code here to test the `String()` result from each regex which is really what was desired in the first place.

A sample of the error message:

```
--- FAIL: TestParseOptionsForExcludePatterns (0.00s)
	Error Trace:	plugin_test.go:68
	Error:      	Not equal: 
	            	expected: &regexp.Regexp{machines:(*sync.Pool)(0xc000339420), expr:"google/*", prog:(*syntax.Prog)(0xc000199410), onepass:(*regexp.onePassProg)(nil), prefix:"google", prefixBytes:[]uint8{0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65}, prefixComplete:false, prefixRune:103, prefixEnd:0x0, cond:0x0, numSubexp:0, subexpNames:[]string{""}, longest:false}
	            	received: &regexp.Regexp{machines:(*sync.Pool)(0xc0003393a0), expr:"google/*", prog:(*syntax.Prog)(0xc000199350), onepass:(*regexp.onePassProg)(nil), prefix:"google", prefixBytes:[]uint8{0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65}, prefixComplete:false, prefixRune:103, prefixEnd:0x0, cond:0x0, numSubexp:0, subexpNames:[]string{""}, longest:false}
	            	
	            	Diff:
	Error Trace:	plugin_test.go:69
	Error:      	Not equal: 
	            	expected: &regexp.Regexp{machines:(*sync.Pool)(0xc000339460), expr:"notgoogle/*", prog:(*syntax.Prog)(0xc000199470), onepass:(*regexp.onePassProg)(nil), prefix:"notgoogle", prefixBytes:[]uint8{0x6e, 0x6f, 0x74, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65}, prefixComplete:false, prefixRune:110, prefixEnd:0x0, cond:0x0, numSubexp:0, subexpNames:[]string{""}, longest:false}
	            	received: &regexp.Regexp{machines:(*sync.Pool)(0xc0003393e0), expr:"notgoogle/*", prog:(*syntax.Prog)(0xc0001993b0), onepass:(*regexp.onePassProg)(nil), prefix:"notgoogle", prefixBytes:[]uint8{0x6e, 0x6f, 0x74, 0x67, 0x6f, 0x6f, 0x67, 0x6c, 0x65}, prefixComplete:false, prefixRune:110, prefixEnd:0x0, cond:0x0, numSubexp:0, subexpNames:[]string{""}, longest:false}
```