### PR TITLE
Bump protoc to 3 6 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ services:
 
 env:
   global:
-    - PROTOC_RELEASE="https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip"
+    - PROTOC_RELEASE="https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip"
     - PROTOC_TARGET="${HOME}/protoc"
     - PATH="${PROTOC_TARGET}/bin:${PATH}"
     - secure: Tbet2rxD8QgjthAo+bxt41qbF2wUPTx0difGK5p4yQISK/njTuT5cqcxnOa4GIbyKtNtx0EgGnyVcQJiQkmZiF6Sabf0mtqU/CQ4PmVV76e9bHwA/CrTtudibMn16ozxuuxvhNxFOMQEhwcQOkW93M/Q9FZUEw9/CGpRGFfSzuA=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 * Added [Sprig](https://github.com/Masterminds/sprig) functions to renderer contexts
 * Added `IsMap` to `MessageField` objects indicating whether or not the field is a map field
 
+### Changed
+
+Bumped protobuf to 3.6.1 in docker container
+
 ### Fixed
 
 * CI issue related to Regexp comparison on Golang master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 FROM debian:jessie-slim
-LABEL maintainer="pseudomuto <david.muto@gmail.com>" protoc_version="3.5.1"
+LABEL maintainer="pseudomuto <david.muto@gmail.com>" protoc_version="3.6.1"
 
 WORKDIR /
 
-ADD https://github.com/google/protobuf/releases/download/v3.5.1/protoc-3.5.1-linux-x86_64.zip ./
+ADD https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip ./
 RUN apt-get -q -y update && \
   apt-get -q -y install unzip && \
-  unzip protoc-3.5.1-linux-x86_64.zip -d ./usr/local && \
-  rm protoc-3.5.1-linux-x86_64.zip && \
+  unzip protoc-3.6.1-linux-x86_64.zip -d ./usr/local && \
+  rm protoc-3.6.1-linux-x86_64.zip && \
   apt-get remove --purge -y unzip && \
   apt-get autoremove && \
   rm -rf /var/lib/apt/lists/*

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -31,8 +31,8 @@
     "protoc-gen-go/descriptor",
     "protoc-gen-go/plugin"
   ]
-  revision = "925541529c1fa6821df4e44ce2723319eb2be768"
-  version = "v1.0.0"
+  revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
+  version = "v1.1.0"
 
 [[projects]]
   name = "github.com/google/uuid"
@@ -87,6 +87,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "91a9a1b9750bac557613efadbba5bdc9e468a6900bc6e469452d833aabe5abe7"
+  inputs-digest = "f591ccb382f677a107a28c19738729c2e935718083ad8622be0458ed1a1e85b5"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/golang/protobuf"
-  version = "^1.0.0"
+  version = "^1.1.0"
 
 [[constraint]]
   name = "github.com/pseudomuto/protokit"

--- a/examples/proto/Customer.proto
+++ b/examples/proto/Customer.proto
@@ -3,6 +3,8 @@ syntax = "proto2";
 
 package com.example;
 
+option ruby_package = "com.example.ruby";
+
 // Use // or /** */ to document messages, fields and enums.
 
 /**


### PR DESCRIPTION
Currently, this project is running with protoc `v3.5.1`. That's a bit old now and lacks support for some newer protobuf features (like `ruby_package` for example).

I've bumped the version to `v3.6.1` for the docker container and CI runs. I also added `ruby_package` to one of the protos to ensure compilation works.

Thanks @jcppkkk for making an issue!
Fixes #367 