### PR TITLE
Correct Proto Doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ You can also generate documentation for a single file. This can be done by passi
 docker run --rm \
   -v $(pwd)/examples/doc:/out \
   -v $(pwd)/examples/proto:/protos \
-  pseudomuto/protoc-gen-doc --doc_opt=markdown,docs.md /protos/Booking.proto [OPTIONALLY LIST MORE FILES]
+  pseudomuto/protoc-gen-doc --doc_opt=markdown,docs.md Booking.proto [OPTIONALLY LIST MORE FILES]
 ```
 
 You can also exclude proto files that match specific path expressions. This is done by passing a second option delimited by `:`.


### PR DESCRIPTION
Docs assume `--proto-path` option is specified, relative path is required when it's not

```
/protos/health.proto: File does not reside within any path specified using --proto_path (or -I).  You must specify a --proto_path which encompasses this file.  Note that the proto_path must be an exact prefix of the .proto file names -- protoc is too dumb to figure out when two paths (e.g. absolute and relative) are equivalent (it's harder than you think).
```