### PR TITLE
Add hugo markdown example

### DIFF
--- a/examples/templates/hugo-md.tmpl
+++ b/examples/templates/hugo-md.tmpl
@@ -1,0 +1,104 @@
+# Protocol Documentation
+<a name="top"></a>
+
+## Table of Contents
+{{range .Files}}
+{{$file_name := .Name}}- [{{.Name}}](#{{.Name}})
+  {{- if .Messages }}
+  {{range .Messages}}  - [{{.LongName}}](#{{.FullName}})
+  {{end}}
+  {{- end -}}
+  {{- if .Enums }}
+  {{range .Enums}}  - [{{.LongName}}](#{{.FullName}})
+  {{end}}
+  {{- end -}}
+  {{- if .Extensions }}
+  {{range .Extensions}}  - [File-level Extensions](#{{$file_name}}-extensions)
+  {{end}}
+  {{- end -}}
+  {{- if .Services }}
+  {{range .Services}}  - [{{.Name}}](#{{.FullName}})
+  {{end}}
+  {{- end -}}
+{{end}}
+- [Scalar Value Types](#scalar-value-types)
+
+{{range .Files}}
+{{$file_name := .Name}}
+<a name="{{.Name}}"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## {{.Name}}
+{{.Description}}
+
+{{range .Messages}}
+<a name="{{.FullName}}"></a>
+
+### {{.LongName}}
+{{.Description}}
+
+{{if .HasFields}}
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+{{range .Fields -}}
+  | {{.Name}} | [{{.LongType}}](#{{.FullType}}) | {{.Label}} | {{if (index .Options "deprecated"|default false)}}**Deprecated.** {{end}}{{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+{{end}}
+{{end}}
+
+{{if .HasExtensions}}
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+{{range .Extensions -}}
+  | {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+{{end}}
+{{end}}
+
+{{end}} <!-- end messages -->
+
+{{range .Enums}}
+<a name="{{.FullName}}"></a>
+
+### {{.LongName}}
+{{.Description}}
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+{{range .Values -}}
+  | {{.Name}} | {{.Number}} | {{nobr .Description}} |
+{{end}}
+
+{{end}} <!-- end enums -->
+
+{{if .HasExtensions}}
+<a name="{{$file_name}}-extensions"></a>
+
+### File-level Extensions
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+{{range .Extensions -}}
+  | {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description}}{{if .DefaultValue}} Default: `{{.DefaultValue}}`{{end}} |
+{{end}}
+{{end}} <!-- end HasExtensions -->
+
+{{range .Services}}
+<a name="{{.FullName}}"></a>
+
+### {{.Name}}
+{{.Description}}
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+{{range .Methods -}}
+  | {{.Name}} | [{{.RequestLongType}}](#{{.RequestFullType}}){{if .RequestStreaming}} stream{{end}} | [{{.ResponseLongType}}](#{{.ResponseFullType}}){{if .ResponseStreaming}} stream{{end}} | {{nobr .Description}} |
+{{end}}
+{{end}} <!-- end services -->
+
+{{end}}
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+{{range .Scalars -}}
+  | <a name="{{.ProtoType}}" /> {{.ProtoType}} | {{.Notes}} | {{.CppType}} | {{.JavaType}} | {{.PythonType}} | {{.GoType}} | {{.CSharp}} | {{.PhpType}} | {{.RubyType}} |
+{{end}}

--- a/examples/templates/hugo-md.tmpl
+++ b/examples/templates/hugo-md.tmpl
@@ -1,47 +1,52 @@
+{{/*
+This template outputs markdown as used by Hugo (https://gohugo.io) static site generator.
+It is based on the original markdown.tmpl from the protoc-gen-doc project.
+
+The generated markdown should be put somewhere under the content folder from your Hugo site.
+For example:
+protoc --doc_out=./doc --doc_opt=hugo-md.tmpl,<hugo_site>content/protoc/index.md proto/*.proto
+
+Then, the hugo development server should pick it up and serve the page at locahost:1313/protoc/,
+in its default configuration.
+*/ -}}
+
+{{define "ref" -}}
+  {{printf "{{< relref \"#%s\" >}}" .}}
+{{- end -}}
+
+---
+title: "Protocol Documentation"
+{{- /* Date is not available in protoc-gen-doc and has been omitted. */}}
+draft: false
+---
+
 # Protocol Documentation
-<a name="top"></a>
 
 ## Table of Contents
-{{range .Files}}
-{{$file_name := .Name}}- [{{.Name}}](#{{.Name}})
-  {{- if .Messages }}
-  {{range .Messages}}  - [{{.LongName}}](#{{.FullName}})
-  {{end}}
-  {{- end -}}
-  {{- if .Enums }}
-  {{range .Enums}}  - [{{.LongName}}](#{{.FullName}})
-  {{end}}
-  {{- end -}}
-  {{- if .Extensions }}
-  {{range .Extensions}}  - [File-level Extensions](#{{$file_name}}-extensions)
-  {{end}}
-  {{- end -}}
-  {{- if .Services }}
-  {{range .Services}}  - [{{.Name}}](#{{.FullName}})
-  {{end}}
-  {{- end -}}
-{{end}}
-- [Scalar Value Types](#scalar-value-types)
+{{- /*
+For this to work, you need a shortcode at layouts/shortcodes/toc.html with the contents:
+
+  {{ .Page.TableOfContents }}
+
+*/}}
+{{`{{< toc >}}`}}
 
 {{range .Files}}
 {{$file_name := .Name}}
-<a name="{{.Name}}"></a>
-<p align="right"><a href="#top">Top</a></p>
 
-## {{.Name}}
+## {{.Name}} {{printf "{id=%q}" .Name}}
 {{.Description}}
 
 {{range .Messages}}
-<a name="{{.FullName}}"></a>
 
-### {{.LongName}}
+### {{.LongName}} {{printf "{id=%q}" .FullName}}
 {{.Description}}
 
 {{if .HasFields}}
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 {{range .Fields -}}
-  | {{.Name}} | [{{.LongType}}](#{{.FullType}}) | {{.Label}} | {{if (index .Options "deprecated"|default false)}}**Deprecated.** {{end}}{{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+  | {{.Name}} | [{{.LongType}}]({{template "ref" .FullType}}) | {{.Label}} | {{if (index .Options "deprecated"|default false)}}**Deprecated.** {{end}}{{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
 {{end}}
 {{end}}
 
@@ -56,9 +61,8 @@
 {{end}} <!-- end messages -->
 
 {{range .Enums}}
-<a name="{{.FullName}}"></a>
 
-### {{.LongName}}
+### {{.LongName}} {{printf "{id=%q}" .FullName}}
 {{.Description}}
 
 | Name | Number | Description |
@@ -70,7 +74,6 @@
 {{end}} <!-- end enums -->
 
 {{if .HasExtensions}}
-<a name="{{$file_name}}-extensions"></a>
 
 ### File-level Extensions
 | Extension | Type | Base | Number | Description |
@@ -81,15 +84,14 @@
 {{end}} <!-- end HasExtensions -->
 
 {{range .Services}}
-<a name="{{.FullName}}"></a>
 
-### {{.Name}}
+### {{.Name}} {{printf "{id=%q}" .FullName}}
 {{.Description}}
 
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 {{range .Methods -}}
-  | {{.Name}} | [{{.RequestLongType}}](#{{.RequestFullType}}){{if .RequestStreaming}} stream{{end}} | [{{.ResponseLongType}}](#{{.ResponseFullType}}){{if .ResponseStreaming}} stream{{end}} | {{nobr .Description}} |
+  | {{.Name}} | [{{.RequestLongType}}]({{template "ref" .RequestFullType}}){{if .RequestStreaming}} stream{{end}} | [{{.ResponseLongType}}](#{{.ResponseFullType}}){{if .ResponseStreaming}} stream{{end}} | {{nobr .Description}} |
 {{end}}
 {{end}} <!-- end services -->
 
@@ -102,3 +104,9 @@
 {{range .Scalars -}}
   | <a name="{{.ProtoType}}" /> {{.ProtoType}} | {{.Notes}} | {{.CppType}} | {{.JavaType}} | {{.PythonType}} | {{.GoType}} | {{.CSharp}} | {{.PhpType}} | {{.RubyType}} |
 {{end}}
+
+{{/*
+  The above named anchors get stripped by Hugo unless the following is set:
+    [markup.goldmark.renderer]
+      unsafe= true
+*/}}


### PR DESCRIPTION
This change adds an example template for a Hugo specific Markdown output.
Hugo is a static site generator: https://gohugo.io.

The new example template is a copy from [resources/markdown.tmpl](https://github.com/pseudomuto/protoc-gen-doc/blob/27bd2775ea68088ac52ebc847c7860e4889b981d/resources/markdown.tmpl). Mostly updated for the way Hugo expects links to be defined, with some additional comments on how to use this template:

````
This template outputs markdown as used by Hugo (https://gohugo.io) static site generator.
It is based on the original markdown.tmpl from the protoc-gen-doc project.

The generated markdown should be put somewhere under the content folder from your Hugo site.
For example:
protoc --doc_out=./doc --doc_opt=hugo-md.tmpl,<hugo_site>content/protoc/index.md proto/*.proto

Then, the hugo development server should pick it up and serve the page at locahost:1313/protoc/,
in its default configuration.
````

I currently use this exact template in my own project to include generated protoc into my Hugo site.
