### PR TITLE
Issue #357 Add extra steps needed for official Maven Central release.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,5 +42,5 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
-          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
+          ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,3 +42,5 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,5 +42,5 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          ORG_GRADLE_PROJECT_SIGNING_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
+          ORG_GRADLE_PROJECT_SIGNING_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           ORG_GRADLE_PROJECT_SIGNING_PASSWORD: ${{ secrets.GPG_SIGNING_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
+/.gradle
 /bin
+/build
 /coverage.txt
 /dist
 /tmp/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,3 +76,9 @@ From an up-to-date master, do the following:
 1. `git push origin master --tags`.
 
 Once the tag is on GitHub, the release action will handle pushing to docker and creating a release in GitHub.
+
+### Publish the Maven artifacts
+
+1. Head over to https://s01.oss.sonatype.org/#stagingRepositories
+1. Verify the contents of the staging repo and close it
+1. After successful closing (test suite is run), release the repo

--- a/build.gradle
+++ b/build.gradle
@@ -1,44 +1,70 @@
 plugins {
   id 'maven-publish'
+  id 'signing'
 }
 
-publishing {
+group = 'io.github.pseudomuto'
 
+publishing {
   publications {
     maven(MavenPublication) {
       groupId = 'io.github.pseudomuto'
       artifactId = rootProject.name
       version = System.getenv("GITHUB_REF_NAME")
 
+      pom {
+        name = groupId + ':' + rootProject.name
+        description = 'This is a documentation generator plugin for the Google Protocol Buffers compiler (protoc). The plugin can generate HTML, JSON, DocBook, and Markdown documentation from comments in your .proto files.'
+        url = 'https://github.com/pseudomuto/protoc-gen-doc'
+        licenses {
+          license {
+            name = 'MIT License'
+            url = 'https://github.com/pseudomuto/protoc-gen-doc/blob/master/LICENSE.md'
+          }
+        }
+        developers {
+          developer {
+            id = 'pseudomuto'
+            name = 'David Muto'
+            email = 'david.muto@gmail.com'
+          }
+        }
+        scm {
+          connection = 'scm:git:git@github.com:pseudomuto/protoc-gen-doc.git'
+          developerConnection = 'scm:git:git@github.com:pseudomuto/protoc-gen-doc.git'
+          url = 'https://github.com/pseudomuto/protoc-gen-doc'
+        }
+      }
+
       //linux 64 arm
-      artifact("$projectDir/dist/protoc-gen-doc_linux_arm64/protoc-gen-doc") {
-          classifier 'linux-aarch_64'
-          extension 'exe'
+      artifact("$buildDir/dist/protoc-gen-doc_linux_arm64") {
+        classifier 'linux-aarch_64'
+        extension 'exe'
       }
       //linux 64 intel
-      artifact("$projectDir/dist/protoc-gen-doc_linux_amd64/protoc-gen-doc") {
-          classifier 'linux-x86_64'
-          extension 'exe'
+      artifact("$buildDir/dist/protoc-gen-doc_linux_amd64") {
+        classifier 'linux-x86_64'
+        extension 'exe'
       }
       //mac 64 arm
-      artifact("$projectDir/dist/protoc-gen-doc_darwin_arm64/protoc-gen-doc") {
-          classifier 'osx-aarch_64'
-          extension 'exe'
+      artifact("$buildDir/dist/protoc-gen-doc_darwin_arm64") {
+        classifier 'osx-aarch_64'
+        extension 'exe'
       }
       //mac 64 intel
-      artifact("$projectDir/dist/protoc-gen-doc_darwin_amd64/protoc-gen-doc") {
-          classifier 'osx-x86_64'
-          extension 'exe'
+      artifact("$buildDir/dist/protoc-gen-doc_darwin_amd64") {
+        classifier 'osx-x86_64'
+        extension 'exe'
       }
       //windows 64 arm
-      artifact("$projectDir/dist/protoc-gen-doc_windows_arm64/protoc-gen-doc.exe") {
-          classifier 'windows-aarch_64'
-          extension 'exe'
+      artifact("$buildDir/dist/protoc-gen-doc_windows_arm64") {
+        classifier 'windows-aarch_64'
+        extension 'exe'
       }
       //windows 64 intel
-      artifact("$projectDir/dist/protoc-gen-doc_windows_amd64/protoc-gen-doc.exe") {
-          classifier 'windows-x86_64'
-          extension 'exe'
+      artifact("$buildDir/dist/protoc-gen-doc_windows_amd64") {
+        classifier 'windows-x86_64'
+        extension 'exe'
       }
     }
   }
@@ -46,7 +72,9 @@ publishing {
   repositories {
     maven {
       name = "OSSRH"
-      url = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+      def releasesRepoUrl = "https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/"
+      def snapshotsRepoUrl = "https://s01.oss.sonatype.org/content/repositories/snapshots/"
+      url = version.endsWith('SNAPSHOT') ? snapshotsRepoUrl : releasesRepoUrl
       credentials {
         username = System.getenv("MAVEN_USERNAME")
         password = System.getenv("MAVEN_PASSWORD")
@@ -54,3 +82,28 @@ publishing {
     }
   }
 }
+
+signing {
+  def signingKey = project.getProperty('SIGNING_PRIVATE_KEY')
+  def signingPassword = project.getProperty('SIGNING_PASSWORD')
+  useInMemoryPgpKeys(signingKey, signingPassword)
+  sign publishing.publications.maven
+}
+
+// A strange issue with signing meant that only the first files (with the same name) got signed.
+// To workaround this, rename all executables to include architecture.
+tasks.register('flattenDistDirectory', Copy) {
+  from("$projectDir/dist") {
+    include "**/protoc-gen-doc"
+    include "**/protoc-gen-doc.exe"
+    eachFile { file ->
+      file.name = file.relativePath.parent.lastName
+      file.relativePath = new RelativePath(true, file.relativePath.segments.drop(1))
+    }
+    includeEmptyDirs = false  
+  }
+  into "$buildDir/dist"
+}
+
+publish.dependsOn flattenDistDirectory
+signMavenPublication.mustRunAfter flattenDistDirectory

--- a/build.gradle
+++ b/build.gradle
@@ -84,8 +84,8 @@ publishing {
 }
 
 signing {
-  def signingKey = project.getProperty('SIGNING_PRIVATE_KEY')
-  def signingPassword = project.getProperty('SIGNING_PASSWORD')
+  def signingKey = project.getProperty('signingKey')
+  def signingPassword = project.getProperty('signingPassword')
   useInMemoryPgpKeys(signingKey, signingPassword)
   sign publishing.publications.maven
 }
@@ -100,7 +100,7 @@ tasks.register('flattenDistDirectory', Copy) {
       file.name = file.relativePath.parent.lastName
       file.relativePath = new RelativePath(true, file.relativePath.segments.drop(1))
     }
-    includeEmptyDirs = false  
+    includeEmptyDirs = false
   }
   into "$buildDir/dist"
 }


### PR DESCRIPTION
To continue #357, the previous commits managed to upload the artifacts to the staging area, however these could not pass the review due to missing requirements.
This required more information to be provided in the POM file, and the releases signed.

This commit adds the information and signing.
The signing is done by GPG and requires 2 new secrets to be provided:
* GPG_SIGNING_KEY: The GPG key in armoured form.
* GPG_SIGNING_PASSWORD: The password for signing the artifact.

If a GPG key does not already exist, this guide can be followed: https://docs.github.com/en/authentication/managing-commit-signature-verification/generating-a-new-gpg-key
The value needed for the GPG_SIGNING_KEY secret can be found by:
* Finding the key name using `gpg --list-keys`
* Outputting the key using `gpg --export-secret-keys --armor [name] > export.asc`
* Copying the contents of that text file to the secret.

Once a release is done, the aritfacts will appear in the staging repository here: https://s01.oss.sonatype.org/#stagingRepositories
This staging repository can be "closed" which will execute the checks.
If all checks pass (they have in my experiments) the "Release" workflow will become availble.

The only strangeness I encountered was that originally only 2 of the releases were getting signed.
This appears to be an issue with publishing files of the same name.
I have worked around the issue by creating a copy of the files under names which include their architecture.
After I did this the signing worked correctly.