### PR TITLE
Issue #357 Fix version number in Maven

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,10 @@ publishing {
       groupId = 'io.github.pseudomuto'
       artifactId = rootProject.name
       version = System.getenv("GITHUB_REF_NAME")
+      // Strip "v" from version number
+      if (version.startsWith("v")) {
+        version = version.substring(1)
+      }
 
       pom {
         name = groupId + ':' + rootProject.name

--- a/examples/gradle/build.gradle
+++ b/examples/gradle/build.gradle
@@ -9,7 +9,7 @@ protobuf {
   }
   plugins {
     doc {
-      artifact = "io.github.pseudomuto:protoc-gen-doc:v1.5.1"
+      artifact = "io.github.pseudomuto:protoc-gen-doc:1.5.1"
     }
   }
 


### PR DESCRIPTION
It is not usual for a version number to be prefixed with v... in Maven.
An easy fix to strip this "v" when it exists.