### PR TITLE
fix: support multi line description in markdown

### DIFF
--- a/examples/doc/example.docbook
+++ b/examples/doc/example.docbook
@@ -554,7 +554,7 @@
               <entry>daily_hire_rate_cents</entry>
               <entry><link linkend="sint32">sint32</link></entry>
               <entry>optional</entry>
-              <entry><para>Cents per day.</para></entry>
+              <entry><para>Cents per day.</para><para>e.g. 20</para></entry>
             </row>
             
           </tbody>

--- a/examples/doc/example.html
+++ b/examples/doc/example.html
@@ -801,7 +801,9 @@
                   <td>daily_hire_rate_cents</td>
                   <td><a href="#sint32">sint32</a></td>
                   <td>optional</td>
-                  <td><p>Cents per day. </p></td>
+                  <td><p>Cents per day.
+
+e.g. 20 </p></td>
                 </tr>
               
             </tbody>

--- a/examples/doc/example.json
+++ b/examples/doc/example.json
@@ -703,7 +703,7 @@
             },
             {
               "name": "daily_hire_rate_cents",
-              "description": "Cents per day.",
+              "description": "Cents per day.\n\ne.g. 20",
               "label": "optional",
               "type": "sint32",
               "longType": "sint32",

--- a/examples/doc/example.md
+++ b/examples/doc/example.md
@@ -237,7 +237,7 @@ Represents a vehicle that can be hired.
 | mileage | [sint32](#sint32) | optional | Current vehicle mileage, if known. |
 | category | [Vehicle.Category](#com-example-Vehicle-Category) | optional | Vehicle category. |
 | daily_hire_rate_dollars | [sint32](#sint32) | optional | Dollars per day. Default: 50 |
-| daily_hire_rate_cents | [sint32](#sint32) | optional | Cents per day. |
+| daily_hire_rate_cents | [sint32](#sint32) | optional | Cents per day.&lt;br&gt;&lt;br&gt;e.g. 20 |
 
 
 

--- a/examples/doc/example.txt
+++ b/examples/doc/example.txt
@@ -189,6 +189,8 @@ Represents a vehicle that can be hired.
 
 |daily_hire_rate_cents | <<sint32,sint32>> |optional |Cents per day.
 
+e.g. 20
+
 |===========================================
 
 

--- a/examples/proto/Vehicle.proto
+++ b/examples/proto/Vehicle.proto
@@ -76,6 +76,8 @@ message Vehicle {
 
   /**
    * Cents per day.
+   *
+   * e.g. 20
    */
   optional sint32 daily_hire_rate_cents = 7;
 

--- a/resources/markdown.tmpl
+++ b/resources/markdown.tmpl
@@ -41,7 +41,7 @@
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 {{range .Fields -}}
-  | {{.Name}} | [{{.LongType}}](#{{.FullType | anchor}}) | {{.Label}} | {{if (index .Options "deprecated"|default false)}}**Deprecated.** {{end}}{{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+  | {{.Name}} | [{{.LongType}}](#{{.FullType | anchor}}) | {{.Label}} | {{if (index .Options "deprecated"|default false)}}**Deprecated.** {{end}}{{.Description | replace "\n" "<br>" | nobr}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
 {{end}}
 {{end}}
 
@@ -49,7 +49,7 @@
 | Extension | Type | Base | Number | Description |
 | --------- | ---- | ---- | ------ | ----------- |
 {{range .Extensions -}}
-  | {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
+  | {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{.Description | replace "\n" "<br>" | nobr}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}} |
 {{end}}
 {{end}}
 
@@ -64,7 +64,7 @@
 | Name | Number | Description |
 | ---- | ------ | ----------- |
 {{range .Values -}}
-  | {{.Name}} | {{.Number}} | {{nobr .Description}} |
+  | {{.Name}} | {{.Number}} | {{.Description | replace "\n" "<br>" | nobr}} |
 {{end}}
 
 {{end}} <!-- end enums -->
@@ -76,7 +76,7 @@
 | Extension | Type | Base | Number | Description |
 | --------- | ---- | ---- | ------ | ----------- |
 {{range .Extensions -}}
-  | {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description}}{{if .DefaultValue}} Default: `{{.DefaultValue}}`{{end}} |
+  | {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{.Description | replace "\n" "<br>" | nobr}}{{if .DefaultValue}} Default: `{{.DefaultValue}}`{{end}} |
 {{end}}
 {{end}} <!-- end HasExtensions -->
 
@@ -89,7 +89,7 @@
 | Method Name | Request Type | Response Type | Description |
 | ----------- | ------------ | ------------- | ------------|
 {{range .Methods -}}
-  | {{.Name}} | [{{.RequestLongType}}](#{{.RequestFullType | anchor}}){{if .RequestStreaming}} stream{{end}} | [{{.ResponseLongType}}](#{{.ResponseFullType | anchor}}){{if .ResponseStreaming}} stream{{end}} | {{nobr .Description}} |
+  | {{.Name}} | [{{.RequestLongType}}](#{{.RequestFullType | anchor}}){{if .RequestStreaming}} stream{{end}} | [{{.ResponseLongType}}](#{{.ResponseFullType | anchor}}){{if .ResponseStreaming}} stream{{end}} | {{.Description | replace "\n" "<br>" | nobr}} |
 {{end}}
 {{end}} <!-- end services -->
 


### PR DESCRIPTION
When working with proto containing multi line comment, the markdown format is not generated properly as line break will corrupt the markdown table.

As we are creating proto that contains comment for the gRCP Gateway documentation, most of our field description have multi line with Example.  It would be a nice addition to support that keyword in the template to, but for now we only want a valid markdown.

This merge request is trying to complete previous merge request that were never completed:
https://github.com/pseudomuto/protoc-gen-doc/pull/445
https://github.com/pseudomuto/protoc-gen-doc/pull/386

thanks for @kelvie-pstg and @ayjayt for their previous attemps.

