### PR TITLE
Issue 336: Replace new line with <br> in markdown tables

### DIFF
--- a/examples/doc/example.docbook
+++ b/examples/doc/example.docbook
@@ -463,7 +463,7 @@
               <entry>model_name</entry>
               <entry><link linkend="string">string</link></entry>
               <entry>required</entry>
-              <entry><para>The car model name, e.g. "Z3".</para></entry>
+              <entry><para>model_name represents the car model name.</para><para>This field typically contains the manufacturer name, e.g. "Porsche 911".</para></entry>
             </row>
             
             <row>

--- a/examples/doc/example.html
+++ b/examples/doc/example.html
@@ -721,7 +721,9 @@
                   <td>model_name</td>
                   <td><a href="#string">string</a></td>
                   <td>required</td>
-                  <td><p>The car model name, e.g. &#34;Z3&#34;. </p></td>
+                  <td><p>model_name represents the car model name.
+
+This field typically contains the manufacturer name, e.g. &#34;Porsche 911&#34;. </p></td>
                 </tr>
               
                 <tr>

--- a/examples/doc/example.json
+++ b/examples/doc/example.json
@@ -564,7 +564,7 @@
             },
             {
               "name": "model_name",
-              "description": "The car model name, e.g. \"Z3\".",
+              "description": "model_name represents the car model name.\n\nThis field typically contains the manufacturer name, e.g. \"Porsche 911\".",
               "label": "required",
               "type": "string",
               "longType": "string",

--- a/examples/doc/example.md
+++ b/examples/doc/example.md
@@ -70,7 +70,7 @@ Represents the status of a vehicle booking.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | id | [int32](#int32) |  | Unique booking status ID. |
-| description | [string](#string) |  | Booking status description. E.g. &#34;Active&#34;. |
+| description | [string](#string) |  | Booking status description. E.g. "Active". |
 
 
 
@@ -195,7 +195,7 @@ Represents a manufacturer of cars.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | id | [int32](#int32) | required | The unique manufacturer ID. |
-| code | [string](#string) | required | A manufacturer code, e.g. &#34;DKL4P&#34;. |
+| code | [string](#string) | required | A manufacturer code, e.g. "DKL4P". |
 | details | [string](#string) | optional | Manufacturer details (minimum orders et.c.). |
 | category | [Manufacturer.Category](#com-example-Manufacturer-Category) | optional | Manufacturer category. Default: CATEGORY_EXTERNAL |
 
@@ -213,8 +213,8 @@ Represents a vehicle model.
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
 | id | [string](#string) | required | The unique model ID. |
-| model_code | [string](#string) | required | The car model code, e.g. &#34;PZ003&#34;. |
-| model_name | [string](#string) | required | The car model name, e.g. &#34;Z3&#34;. |
+| model_code | [string](#string) | required | The car model code, e.g. "PZ003". |
+| model_name | [string](#string) | required | model_name represents the car model name.<br><br>This field typically contains the manufacturer name, e.g. "Porsche 911". |
 | daily_hire_rate_dollars | [sint32](#sint32) | required | Dollars per day. |
 | daily_hire_rate_cents | [sint32](#sint32) | required | Cents per day. |
 
@@ -257,8 +257,8 @@ Represents a vehicle category. E.g. &#34;Sedan&#34; or &#34;Truck&#34;.
 
 | Field | Type | Label | Description |
 | ----- | ---- | ----- | ----------- |
-| code | [string](#string) | required | Category code. E.g. &#34;S&#34;. |
-| description | [string](#string) | required | Category name. E.g. &#34;Sedan&#34;. |
+| code | [string](#string) | required | Category code. E.g. "S". |
+| description | [string](#string) | required | Category name. E.g. "Sedan". |
 
 
 

--- a/examples/doc/example.txt
+++ b/examples/doc/example.txt
@@ -158,7 +158,9 @@ Represents a vehicle model.
 
 |model_code | <<string,string>> |required |The car model code, e.g. "PZ003".
 
-|model_name | <<string,string>> |required |The car model name, e.g. "Z3".
+|model_name | <<string,string>> |required |model_name represents the car model name.
+
+This field typically contains the manufacturer name, e.g. "Porsche 911".
 
 |daily_hire_rate_dollars | <<sint32,sint32>> |required |Dollars per day.
 

--- a/examples/proto/Vehicle.proto
+++ b/examples/proto/Vehicle.proto
@@ -38,7 +38,11 @@ extend Manufacturer {
 message Model {
   required string id         = 1; /** The unique model ID. */
   required string model_code = 2; /** The car model code, e.g. "PZ003". */
-  required string model_name = 3; /** The car model name, e.g. "Z3". */
+
+  // model_name represents the car model name.
+  //
+  // This field typically contains the manufacturer name, e.g. "Porsche 911".
+  required string model_name = 3;
 
   required sint32 daily_hire_rate_dollars = 4; /// Dollars per day.
   required sint32 daily_hire_rate_cents   = 5; /// Cents per day.

--- a/filters.go
+++ b/filters.go
@@ -28,6 +28,18 @@ func ParaFilter(content string) string {
 
 // NoBrFilter removes single CR and LF from content.
 func NoBrFilter(content string) string {
+	paragraphs := contentToParagraphs(content)
+	return strings.Join(paragraphs, "\n\n")
+}
+
+// BrFilterMD removes single CR and LF from content and replaces it with unescaped
+// HTML line breaks for markdown.
+func BrFilterMD(content string) template.HTML {
+	paragraphs := contentToParagraphs(content)
+	return template.HTML(strings.Join(paragraphs, "<br><br>"))
+}
+
+func contentToParagraphs(content string) []string {
 	normalized := strings.Replace(content, "\r\n", "\n", -1)
 	paragraphs := multiNewlinePattern.Split(normalized, -1)
 	for i, p := range paragraphs {
@@ -35,7 +47,7 @@ func NoBrFilter(content string) string {
 		withoutLF := strings.Replace(withoutCR, "\n", " ", -1)
 		paragraphs[i] = spacePattern.ReplaceAllString(withoutLF, " ")
 	}
-	return strings.Join(paragraphs, "\n\n")
+	return paragraphs
 }
 
 // AnchorFilter replaces all special characters with URL friendly dashes

--- a/filters_test.go
+++ b/filters_test.go
@@ -50,6 +50,20 @@ func TestNoBrFilter(t *testing.T) {
 	}
 }
 
+func TestBrMdFilter(t *testing.T) {
+	tests := map[string]string{
+		"My content":                     "My content",
+		"My content \r\nHere.":           "My content Here.",
+		"My\n content\r right\r\n here.": "My content right here.",
+		"My\ncontent\rright\r\nhere.":    "My content right here.",
+		"My content.\n\nMore content.":   "My content.<br><br>More content.",
+	}
+
+	for input, output := range tests {
+		require.Equal(t, html.HTML(output), BrFilterMD(input))
+	}
+}
+
 func TestAnchorFilter(t *testing.T) {
 	tests := map[string]string{
 		"com/example/test.proto":  "com_example_test-proto",

--- a/renderer.go
+++ b/renderer.go
@@ -78,6 +78,7 @@ var funcMap = map[string]interface{}{
 	"p":      PFilter,
 	"para":   ParaFilter,
 	"nobr":   NoBrFilter,
+	"brmd":   BrFilterMD,
 	"anchor": AnchorFilter,
 }
 


### PR DESCRIPTION
Addressing the issue of incorrect new lines in markdown documentation by replacing new lines with`<br>` tags.

Original issue:
https://github.com/pseudomuto/protoc-gen-doc/issues/366

Related PRs addressing the same issue:

This one is actually pretty recent, but escapes the break tags:
- https://github.com/pseudomuto/protoc-gen-doc/pull/486

This one seems to have a failing build:
- https://github.com/pseudomuto/protoc-gen-doc/pull/445

This one's missing the examples:
- https://github.com/pseudomuto/protoc-gen-doc/pull/386