### PR TITLE
Feature/separate files

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,24 @@ example](examples/gradle).
 The plugin is invoked by passing the `--doc_out`, and `--doc_opt` options to the `protoc` compiler. The option has the
 following format:
 
-    --doc_opt=<FORMAT>|<TEMPLATE_FILENAME>,<OUT_FILENAME>[,default|source_relative]
+    --doc_opt=<FORMAT>|<TEMPLATE_FILENAME>,<OUT_FILENAME>[,default|source_relative][,default|separate_files]
 
 The format may be one of the built-in ones ( `docbook`, `html`, `markdown` or `json`)
 or the name of a file containing a custom [Go template][gotemplate].
 
+### `source_relative`
+
 If the `source_relative` flag is specified, the output file is written in the same relative directory as the input file.
+
+### `separate_files`
+
+If the `separate_files` flag is specified, there will be one file outputted per input file and the second parameter,
+`<OUT_FILENAME>`, will be used as the extension of the outputted files.
+
+For example, the following will result in the outputted files `foo.md` and `bar.md` since `md` is passed as the second parameter.
+```
+--doc_opt=markdown,md,source_relative,separate_files foo.proto bar.proto
+```
 
 ### Using the Docker Image (Recommended)
 

--- a/cmd/protoc-gen-doc/flags.go
+++ b/cmd/protoc-gen-doc/flags.go
@@ -24,6 +24,9 @@ protoc --doc_out=. --doc_opt=custom.tmpl,docs.txt protos/*.proto
 EXAMPLE: Generate docs relative to source protos
 protoc --doc_out=. --doc_opt=html,index.html,source_relative protos/*.proto
 
+EXAMPLE: Generate docs relative to source protos, one output file per input file
+protoc --doc_out=. --doc_opt=html,html,source_relative,separate_files protos/*.proto
+
 See https://github.com/pseudomuto/protoc-gen-doc for more details.
 `
 

--- a/plugin.go
+++ b/plugin.go
@@ -129,7 +129,7 @@ OUTER:
 // ParseOptions parses plugin options from a CodeGeneratorRequest. It does this by splitting the `Parameter` field from
 // the request object and parsing out the type of renderer to use and the name of the file to be generated.
 //
-// The parameter (`--doc_opt`) must be of the format <TYPE|TEMPLATE_FILE>,<OUTPUT_FILE>[,default|source_relative]:<EXCLUDE_PATTERN>,<EXCLUDE_PATTERN>*.
+// The parameter (`--doc_opt`) must be of the format <TYPE|TEMPLATE_FILE>,<OUTPUT_FILE>[,default|source_relative][,default|separate_files]:<EXCLUDE_PATTERN>,<EXCLUDE_PATTERN>*.
 // The file will be written to the directory specified with the `--doc_out` argument to protoc.
 func ParseOptions(req *plugin_go.CodeGeneratorRequest) (*PluginOptions, error) {
 	options := &PluginOptions{


### PR DESCRIPTION
Hello! I've come across a use case where it would be nice to have one output file per input file. I'm setting up a static documentation site for Proto files and the UX is better when the output mirrors the input instead of having them grouped together on one page (regardless of using `source_relative` or not).

This PR adds support for the `separate_files` flag which outputs one file per input file instead of grouping input files into one output file.

Usage:
```
protoc --doc_out=. --doc_opt=markdown,md,source_relative,separate_files **/*.proto
```

Notes on behaviour:
* The value passed in for the second parameter (the name of the output file) is used as the extension of each output file. For example, if you pass `md` like in the example above, the output files would be `<filename>.md`.
* This flag can be used with `source_relative` or without, it does not change `source_relative`'s functionality.

I'm an iOS developer and Go is a little foreign to me, so please feel free to give feedback on conventions or anything else that doesn't seem to fit quite right. Thanks!