### PR TITLE
Port over validation annotation template

### DIFF
--- a/resources/markdown.tmpl
+++ b/resources/markdown.tmpl
@@ -45,6 +45,19 @@
 {{end}}
 {{end}}
 
+{{$message := .}}
+{{- range .FieldOptions}}
+{{$option := .}}
+{{if eq . "validator.field" "validate.rules" }}
+#### Validated Fields
+| Field | Validations |
+| ----- | ----------- |
+{{range $message.FieldsWithOption . -}}
+  | {{.Name}} | {{range (.Option $option).Rules}}• {{.Name}}: `{{.Value}}`<br>{{end}} |
+{{end}}
+{{end}}
+{{end}}
+
 {{if .HasExtensions}}
 | Extension | Type | Base | Number | Description |
 | --------- | ---- | ---- | ------ | ----------- |


### PR DESCRIPTION
Porting the templating logic for validation annotations from the html template
https://github.com/pseudomuto/protoc-gen-doc/blob/00cf69cfa432cb7ff4218bd2106290716423400e/resources/html.tmpl#L238