### PR TITLE
feat: integrate a full template for asciidoc formatted documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ build/examples: bin/protoc build tmp/googleapis examples/proto/*.proto examples/
 	@$(EXAMPLE_CMD) --doc_opt=html,example.html:Ignore* examples/proto/*.proto
 	@$(EXAMPLE_CMD) --doc_opt=json,example.json:Ignore* examples/proto/*.proto
 	@$(EXAMPLE_CMD) --doc_opt=markdown,example.md:Ignore* examples/proto/*.proto
+	@$(EXAMPLE_CMD) --doc_opt=asciidoc,example.adoc:Ignore* examples/proto/*.proto
 	@$(EXAMPLE_CMD) --doc_opt=examples/templates/asciidoc.tmpl,example.txt:Ignore* examples/proto/*.proto
 
 ##@: Dev
@@ -71,6 +72,7 @@ test/docker: bin/protoc tmp/googleapis release/snapshot ## Run the docker e2e te
 	@$(DOCKER_CMD) --doc_opt=html,example.html:Ignore*
 	@$(DOCKER_CMD) --doc_opt=json,example.json:Ignore*
 	@$(DOCKER_CMD) --doc_opt=markdown,example.md:Ignore*
+	@$(DOCKER_CMD) --doc_opt=asciidoc,example.adoc:Ignore*
 	@$(DOCKER_CMD) --doc_opt=/templates/asciidoc.tmpl,example.txt:Ignore*
 
 ##@: Release

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Go Report Card][goreport-svg]][goreport-url]
 
 This is a documentation generator plugin for the Google Protocol Buffers compiler (`protoc`). The plugin can generate
-HTML, JSON, DocBook, and Markdown documentation from comments in your `.proto` files.
+HTML, JSON, DocBook, Asciidoc, and Markdown documentation from comments in your `.proto` files.
 
 It supports proto2 and proto3, and can handle having both in the same context (see [examples](examples/) for proof).
 
@@ -31,7 +31,7 @@ following format:
 
     --doc_opt=<FORMAT>|<TEMPLATE_FILENAME>,<OUT_FILENAME>[,default|source_relative]
 
-The format may be one of the built-in ones ( `docbook`, `html`, `markdown` or `json`)
+The format may be one of the built-in ones ( `docbook`, `html`, `markdown`, `asciidoc` or `json`)
 or the name of a file containing a custom [Go template][gotemplate].
 
 If the `source_relative` flag is specified, the output file is written in the same relative directory as the input file.

--- a/examples/doc/example.adoc
+++ b/examples/doc/example.adoc
@@ -1,0 +1,423 @@
+= [[top]]Protocol Documentation
+:toc:
+
+
+
+[[Booking-proto]]
+== Booking.proto
+
+[.text-right]
+xref:top[Top]
+
+Booking related messages.
+
+This file is really just an example. The data model is completely
+fictional.
+
+
+[[com-example-Booking]]
+=== Booking
+
+Represents the booking of a vehicle.
+
+Vehicles are some cool shit. But drive carefully!
+
+
+[%header,cols="1,1,1,4"]
+|===
+| Field | Type | Label | Description
+
+| vehicle_id | xref:int32[int32] |  | ID of booked vehicle.
+
+| customer_id | xref:int32[int32] |  | Customer that booked the vehicle.
+
+| status | xref:com-example-BookingStatus[BookingStatus] |  | Status of the booking.
+
+| confirmation_sent | xref:bool[bool] |  | Has booking confirmation been sent?
+
+| payment_received | xref:bool[bool] |  | Has payment been received?
+
+| color_preference | xref:string[string] |  | __Deprecated.__ Color preference of the customer.
+
+
+
+|===
+
+
+
+
+
+[[com-example-BookingStatus]]
+=== BookingStatus
+
+Represents the status of a vehicle booking.
+
+
+[%header,cols="1,1,1,4"]
+|===
+| Field | Type | Label | Description
+
+| id | xref:int32[int32] |  | Unique booking status ID.
+
+| description | xref:string[string] |  | Booking status description. E.g. &#34;Active&#34;.
+
+
+
+|===
+
+
+
+
+
+[[com-example-BookingStatusID]]
+=== BookingStatusID
+
+Represents the booking status ID.
+
+
+[%header,cols="1,1,1,4"]
+|===
+| Field | Type | Label | Description
+
+| id | xref:int32[int32] |  | Unique booking status ID.
+
+
+
+|===
+
+
+
+
+
+[[com-example-EmptyBookingMessage]]
+=== EmptyBookingMessage
+
+An empty message for testing
+
+
+
+
+
+
+// end messages
+
+
+// end enums
+
+
+// end HasExtensions
+
+
+
+[[com-example-BookingService]]
+=== BookingService
+
+Service for handling vehicle bookings.
+
+[%header,cols="1,1,1,3"]
+|===
+| Method Name | Request Type | Response Type | Description
+
+| BookVehicle | xref:com-example-Booking[Booking] | xref:com-example-BookingStatus[BookingStatus] | Used to book a vehicle. Pass in a Booking and a BookingStatus will be returned.
+
+| BookingUpdates | xref:com-example-BookingStatusID[BookingStatusID] | xref:com-example-BookingStatus[BookingStatus] stream | Used to subscribe to updates of the BookingStatus.
+
+
+|===
+
+// end services
+
+
+
+[[Customer-proto]]
+== Customer.proto
+
+[.text-right]
+xref:top[Top]
+
+This file has messages for describing a customer.
+
+
+[[com-example-Address]]
+=== Address
+
+Represents a mail address.
+
+
+[%header,cols="1,1,1,4"]
+|===
+| Field | Type | Label | Description
+
+| address_line_1 | xref:string[string] | required | First address line.
+
+| address_line_2 | xref:string[string] | optional | Second address line.
+
+| address_line_3 | xref:string[string] | optional | Second address line.
+
+| town | xref:string[string] | required | Address town.
+
+| county | xref:string[string] | optional | Address county, if applicable.
+
+| country | xref:string[string] | required | Address country.
+
+
+
+|===
+
+
+
+
+
+[[com-example-Customer]]
+=== Customer
+
+Represents a customer.
+
+
+[%header,cols="1,1,1,4"]
+|===
+| Field | Type | Label | Description
+
+| id | xref:int32[int32] | required | Unique customer ID.
+
+| first_name | xref:string[string] | required | Customer first name.
+
+| last_name | xref:string[string] | required | Customer last name.
+
+| details | xref:string[string] | optional | Customer details.
+
+| email_address | xref:string[string] | optional | Customer e-mail address.
+
+| phone_number | xref:string[string] | repeated | Customer phone numbers, primary first.
+
+| mail_addresses | xref:com-example-Address[Address] | repeated | Customer mail addresses, primary first.
+
+
+
+|===
+
+
+
+
+
+// end messages
+
+
+// end enums
+
+
+// end HasExtensions
+
+
+// end services
+
+
+
+[[Vehicle-proto]]
+== Vehicle.proto
+
+[.text-right]
+xref:top[Top]
+
+Messages describing manufacturers / vehicles.
+
+
+[[com-example-Manufacturer]]
+=== Manufacturer
+
+Represents a manufacturer of cars.
+
+
+[%header,cols="1,1,1,4"]
+|===
+| Field | Type | Label | Description
+
+| id | xref:int32[int32] | required | The unique manufacturer ID.
+
+| code | xref:string[string] | required | A manufacturer code, e.g. &#34;DKL4P&#34;.
+
+| details | xref:string[string] | optional | Manufacturer details (minimum orders et.c.).
+
+| category | xref:com-example-Manufacturer-Category[Manufacturer.Category] | optional | Manufacturer category. Default: CATEGORY_EXTERNAL
+
+
+
+|===
+
+
+
+
+
+[[com-example-Model]]
+=== Model
+
+Represents a vehicle model.
+
+
+[%header,cols="1,1,1,4"]
+|===
+| Field | Type | Label | Description
+
+| id | xref:string[string] | required | The unique model ID.
+
+| model_code | xref:string[string] | required | The car model code, e.g. &#34;PZ003&#34;.
+
+| model_name | xref:string[string] | required | The car model name, e.g. &#34;Z3&#34;.
+
+| daily_hire_rate_dollars | xref:sint32[sint32] | required | Dollars per day.
+
+| daily_hire_rate_cents | xref:sint32[sint32] | required | Cents per day.
+
+
+
+|===
+
+
+
+
+
+[[com-example-Vehicle]]
+=== Vehicle
+
+Represents a vehicle that can be hired.
+
+
+[%header,cols="1,1,1,4"]
+|===
+| Field | Type | Label | Description
+
+| id | xref:int32[int32] | required | Unique vehicle ID.
+
+| model | xref:com-example-Model[Model] | required | Vehicle model.
+
+| reg_number | xref:string[string] | required | Vehicle registration number.
+
+| mileage | xref:sint32[sint32] | optional | Current vehicle mileage, if known.
+
+| category | xref:com-example-Vehicle-Category[Vehicle.Category] | optional | Vehicle category.
+
+| daily_hire_rate_dollars | xref:sint32[sint32] | optional | Dollars per day. Default: 50
+
+| daily_hire_rate_cents | xref:sint32[sint32] | optional | Cents per day.
+
+
+
+|===
+
+
+
+[%header,cols="1,1,1,1,3"]
+|===
+| Extension | Type | Base | Number | Description
+
+| series | string | Model | 100 | Vehicle model series.
+
+
+|===
+
+
+
+[[com-example-Vehicle-Category]]
+=== Vehicle.Category
+
+Represents a vehicle category. E.g. &#34;Sedan&#34; or &#34;Truck&#34;.
+
+
+[%header,cols="1,1,1,4"]
+|===
+| Field | Type | Label | Description
+
+| code | xref:string[string] | required | Category code. E.g. &#34;S&#34;.
+
+| description | xref:string[string] | required | Category name. E.g. &#34;Sedan&#34;.
+
+
+
+|===
+
+
+
+
+
+// end messages
+
+
+
+[[com-example-Manufacturer-Category]]
+=== Manufacturer.Category
+
+Manufacturer category. A manufacturer may be either inhouse or external.
+
+[%header,cols="1,1,4"]
+|===
+| Name | Number | Description
+
+| CATEGORY_INHOUSE | 0 | The manufacturer is inhouse.
+
+| CATEGORY_EXTERNAL | 1 | The manufacturer is external.
+
+
+|===
+
+// end enums
+
+
+
+[[Vehicle-proto-extensions]]
+=== File-level Extensions
+
+[%header,cols="1,1,1,1,2"]
+|===
+| Extension | Type | Base | Number | Description
+
+| country | string | Manufacturer | 100 | Manufacturer country. Default: `China`
+
+|===
+
+// end HasExtensions
+
+
+// end services
+
+
+
+[[scalar-value-types]]
+== Scalar Value Types
+
+[%header,cols="1,3,1,1,1,1,1,1,1"]
+|===
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby
+
+[[double]]
+| double |  | double | double | float | float64 | double | float | Float
+[[float]]
+| float |  | float | float | float | float32 | float | float | Float
+[[int32]]
+| int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required)
+[[int64]]
+| int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long | int64 | long | integer/string | Bignum
+[[uint32]]
+| uint32 | Uses variable-length encoding. | uint32 | int | int/long | uint32 | uint | integer | Bignum or Fixnum (as required)
+[[uint64]]
+| uint64 | Uses variable-length encoding. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum or Fixnum (as required)
+[[sint32]]
+| sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required)
+[[sint64]]
+| sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long | int64 | long | integer/string | Bignum
+[[fixed32]]
+| fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int | uint32 | uint | integer | Bignum or Fixnum (as required)
+[[fixed64]]
+| fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum
+[[sfixed32]]
+| sfixed32 | Always four bytes. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required)
+[[sfixed64]]
+| sfixed64 | Always eight bytes. | int64 | long | int/long | int64 | long | integer/string | Bignum
+[[bool]]
+| bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass
+[[string]]
+| string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8)
+[[bytes]]
+| bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT)
+
+
+|===

--- a/renderer.go
+++ b/renderer.go
@@ -20,6 +20,7 @@ const (
 	RenderTypeHTML
 	RenderTypeJSON
 	RenderTypeMarkdown
+	RenderTypeAsciidoc
 )
 
 // NewRenderType creates a RenderType from the supplied string. If the type is not known, (0, error) is returned. It is
@@ -34,6 +35,8 @@ func NewRenderType(renderType string) (RenderType, error) {
 		return RenderTypeJSON, nil
 	case "markdown":
 		return RenderTypeMarkdown, nil
+	case "asciidoc":
+		return RenderTypeAsciidoc, nil
 	}
 
 	return 0, errors.New("Invalid render type")
@@ -54,6 +57,8 @@ func (rt RenderType) renderer() (Processor, error) {
 		return new(jsonRenderer), nil
 	case RenderTypeMarkdown:
 		return &htmlRenderer{string(tmpl)}, nil
+	case RenderTypeAsciidoc:
+		return &htmlRenderer{string(tmpl)}, nil
 	}
 
 	return nil, errors.New("Unable to create a processor")
@@ -69,6 +74,8 @@ func (rt RenderType) template() ([]byte, error) {
 		return nil, nil
 	case RenderTypeMarkdown:
 		return markdownTmpl, nil
+	case RenderTypeAsciidoc:
+		return asciidocTmpl, nil
 	}
 
 	return nil, errors.New("Couldn't find template for render type")

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -37,9 +37,10 @@ func TestNewRenderType(t *testing.T) {
 		RenderTypeHTML,
 		RenderTypeJSON,
 		RenderTypeMarkdown,
+		RenderTypeAsciidoc,
 	}
 
-	supplied := []string{"docbook", "html", "json", "markdown"}
+	supplied := []string{"docbook", "html", "json", "markdown", "asciidoc"}
 
 	for idx, input := range supplied {
 		rt, err := NewRenderType(input)

--- a/resources.go
+++ b/resources.go
@@ -11,6 +11,8 @@ var (
 	htmlTmpl []byte
 	//go:embed resources/markdown.tmpl
 	markdownTmpl []byte
+	//go:embed resources/asciidoc.tmpl
+	asciidocTmpl []byte
 	//go:embed resources/scalars.json
 	scalarsJSON []byte
 )

--- a/resources/asciidoc.tmpl
+++ b/resources/asciidoc.tmpl
@@ -1,0 +1,116 @@
+= [[top]]Protocol Documentation
+:toc:
+
+{{range .Files}}
+{{$file_name := .Name}}
+[[{{.Name | anchor}}]]
+== {{.Name}}
+
+[.text-right]
+xref:top[Top]
+
+{{.Description}}
+
+{{range .Messages}}
+[[{{.FullName | anchor}}]]
+=== {{.LongName}}
+
+{{.Description}}
+
+{{if .HasFields}}
+[%header,cols="1,1,1,4"]
+|===
+| Field | Type | Label | Description
+
+{{range .Fields -}}
+| {{.Name}} | xref:{{.FullType | anchor}}[{{.LongType}}] | {{.Label}} | {{if (index .Options "deprecated"|default false)}}__Deprecated.__ {{end}}{{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}}
+
+{{end}}
+
+|===
+{{end}}
+
+{{if .HasExtensions}}
+[%header,cols="1,1,1,1,3"]
+|===
+| Extension | Type | Base | Number | Description
+
+{{range .Extensions -}}
+| {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description}}{{if .DefaultValue}} Default: {{.DefaultValue}}{{end}}
+
+{{end}}
+|===
+{{end}}
+
+{{end}}
+// end messages
+
+{{range .Enums}}
+
+[[{{.FullName | anchor}}]]
+=== {{.LongName}}
+
+{{.Description}}
+
+[%header,cols="1,1,4"]
+|===
+| Name | Number | Description
+
+{{range .Values -}}
+| {{.Name}} | {{.Number}} | {{nobr .Description}}
+
+{{end}}
+|===
+{{end}}
+// end enums
+
+{{if .HasExtensions}}
+
+[[{{$file_name | anchor}}-extensions]]
+=== File-level Extensions
+
+[%header,cols="1,1,1,1,2"]
+|===
+| Extension | Type | Base | Number | Description
+
+{{range .Extensions -}}
+| {{.Name}} | {{.LongType}} | {{.ContainingLongType}} | {{.Number}} | {{nobr .Description}}{{if .DefaultValue}} Default: `{{.DefaultValue}}`{{end}}
+{{end}}
+|===
+{{end}}
+// end HasExtensions
+
+{{range .Services}}
+
+[[{{.FullName | anchor}}]]
+=== {{.Name}}
+
+{{.Description}}
+
+[%header,cols="1,1,1,3"]
+|===
+| Method Name | Request Type | Response Type | Description
+
+{{range .Methods -}}
+| {{.Name}} | xref:{{.RequestFullType | anchor}}[{{.RequestLongType}}]{{if .RequestStreaming}} stream{{end}} | xref:{{.ResponseFullType | anchor}}[{{.ResponseLongType}}]{{if .ResponseStreaming}} stream{{end}} | {{nobr .Description}}
+
+{{end}}
+|===
+{{end}}
+// end services
+
+{{end}}
+
+[[scalar-value-types]]
+== Scalar Value Types
+
+[%header,cols="1,3,1,1,1,1,1,1,1"]
+|===
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby
+
+{{range .Scalars -}}
+[[{{.ProtoType | anchor}}]]
+| {{.ProtoType}} | {{.Notes}} | {{.CppType}} | {{.JavaType}} | {{.PythonType}} | {{.GoType}} | {{.CSharp}} | {{.PhpType}} | {{.RubyType}}
+{{end}}
+
+|===


### PR DESCRIPTION

Adds an integrated asciidoc template that is fully equivalent to the Markdown version. GitHub renders this correctly with the exception that the "top" links are not right-aligned with GitHub's renderer:

![Screenshot 2022-11-30 at 11 04 40](https://user-images.githubusercontent.com/209336/204780215-9558c8bb-c206-4a20-a2c4-522db2182990.png)

I have left the example asciidoc partial template and its output with the `.txt` extension as is, though it probably could be removed.