### PR TITLE
Fix absolute doc_opt paths on Windows (#497)

### DIFF
--- a/plugin_test.go
+++ b/plugin_test.go
@@ -97,6 +97,31 @@ func TestParseOptionsWithInvalidValues(t *testing.T) {
 	}
 }
 
+func TestParseOptionsForCustomTemplateWindowsAbsolutePath(t *testing.T) {
+	req := new(plugin_go.CodeGeneratorRequest)
+	req.Parameter = proto.String("C:\\path\\to\\template.tmpl,C:\\path\\to\\output")
+
+	options, err := ParseOptions(req)
+	require.NoError(t, err)
+
+	require.Equal(t, RenderTypeHTML, options.Type)
+	require.Equal(t, "C:\\path\\to\\template.tmpl", options.TemplateFile)
+	require.Equal(t, "C:\\path\\to\\output", options.OutputFile)
+}
+
+func TestParseOptionsForCustomTemplateWindowsAbsolutePathPlusExcludes(t *testing.T) {
+	req := new(plugin_go.CodeGeneratorRequest)
+	req.Parameter = proto.String("C:\\path\\to\\template.tmpl,C:\\path\\to\\output:test.*")
+
+	options, err := ParseOptions(req)
+	require.NoError(t, err)
+
+	require.Equal(t, RenderTypeHTML, options.Type)
+	require.Equal(t, "C:\\path\\to\\template.tmpl", options.TemplateFile)
+	require.Equal(t, "C:\\path\\to\\output", options.OutputFile)
+	require.Equal(t, "test.*", options.ExcludePatterns[0].String())
+}
+
 func TestRunPluginForBuiltinTemplate(t *testing.T) {
 	set, _ := utils.LoadDescriptorSet("fixtures", "fileset.pb")
 	req := utils.CreateGenRequest(set, "Booking.proto", "Vehicle.proto", "nested/Book.proto")


### PR DESCRIPTION
This PR contains a fix for the Windows absolute path problem described under issue #497.

It implements a heuristic that attempts to detect the specific Windows absolute path situation in the first two parameter parts (template file and output file) and rectifies it by recombining the accidentially-splitted parts. Unfortunately that seems to be the best-possible solution to the underlying problem as long as the --doc_opt format specification is to be kept as-is.

Tests have been added that fail with the original code, but succeed with the fix.