### PR TITLE
Issue #357 Upgrade gradle to remove signing workarounds

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Publish package
         uses: gradle/gradle-build-action@v2
         with:
-          gradle-version: 7.4
+          gradle-version: 7.5.1
           arguments: publish
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/build.gradle
+++ b/build.gradle
@@ -41,32 +41,32 @@ publishing {
       }
 
       //linux 64 arm
-      artifact("$buildDir/dist/protoc-gen-doc_linux_arm64") {
+      artifact("$projectDir/dist/protoc-gen-doc_linux_arm64/protoc-gen-doc") {
         classifier 'linux-aarch_64'
         extension 'exe'
       }
       //linux 64 intel
-      artifact("$buildDir/dist/protoc-gen-doc_linux_amd64") {
+      artifact("$projectDir/dist/protoc-gen-doc_linux_amd64/protoc-gen-doc") {
         classifier 'linux-x86_64'
         extension 'exe'
       }
       //mac 64 arm
-      artifact("$buildDir/dist/protoc-gen-doc_darwin_arm64") {
+      artifact("$projectDir/dist/protoc-gen-doc_darwin_arm64/protoc-gen-doc") {
         classifier 'osx-aarch_64'
         extension 'exe'
       }
       //mac 64 intel
-      artifact("$buildDir/dist/protoc-gen-doc_darwin_amd64") {
+      artifact("$projectDir/dist/protoc-gen-doc_darwin_amd64/protoc-gen-doc") {
         classifier 'osx-x86_64'
         extension 'exe'
       }
       //windows 64 arm
-      artifact("$buildDir/dist/protoc-gen-doc_windows_arm64") {
+      artifact("$projectDir/dist/protoc-gen-doc_windows_arm64/protoc-gen-doc.exe") {
         classifier 'windows-aarch_64'
         extension 'exe'
       }
       //windows 64 intel
-      artifact("$buildDir/dist/protoc-gen-doc_windows_amd64") {
+      artifact("$projectDir/dist/protoc-gen-doc_windows_amd64/protoc-gen-doc.exe") {
         classifier 'windows-x86_64'
         extension 'exe'
       }
@@ -93,21 +93,3 @@ signing {
   useInMemoryPgpKeys(signingKey, signingPassword)
   sign publishing.publications.maven
 }
-
-// A strange issue with signing meant that only the first files (with the same name) got signed.
-// To workaround this, rename all executables to include architecture.
-tasks.register('flattenDistDirectory', Copy) {
-  from("$projectDir/dist") {
-    include "**/protoc-gen-doc"
-    include "**/protoc-gen-doc.exe"
-    eachFile { file ->
-      file.name = file.relativePath.parent.lastName
-      file.relativePath = new RelativePath(true, file.relativePath.segments.drop(1))
-    }
-    includeEmptyDirs = false
-  }
-  into "$buildDir/dist"
-}
-
-publish.dependsOn flattenDistDirectory
-signMavenPublication.mustRunAfter flattenDistDirectory


### PR DESCRIPTION
The issue which required us to rename files was fixed in gradle 7.5.1. This cleanup updates to that version and remove the workaround previously needed.