### PR TITLE
Add sortable ServiceMethods for template use with requisite unit tests

### DIFF
--- a/renderer.go
+++ b/renderer.go
@@ -90,10 +90,10 @@ type Processor interface {
 // supplying a non-empty string as the last parameter.
 //
 // Example: generating an HTML template (assuming you've got a Template object)
-//     data, err := RenderTemplate(RenderTypeHTML, &template, "")
+//	data, err := RenderTemplate(RenderTypeHTML, &template, "")
 //
 // Example: generating a custom template (assuming you've got a Template object)
-//     data, err := RenderTemplate(RenderTypeHTML, &template, "{{range .Files}}{{.Name}}{{end}}")
+//	data, err := RenderTemplate(RenderTypeHTML, &template, "{{range .Files}}{{.Name}}{{end}}")
 func RenderTemplate(kind RenderType, template *Template, inputTemplate string) ([]byte, error) {
 	if inputTemplate != "" {
 		processor := &textRenderer{inputTemplate}
@@ -113,6 +113,7 @@ type textRenderer struct {
 }
 
 func (mr *textRenderer) Apply(template *Template) ([]byte, error) {
+	funcMap["SortServiceMethods"] = SortServiceMethods
 	tmpl, err := text_template.New("Text Template").Funcs(funcMap).Funcs(sprig.TxtFuncMap()).Parse(mr.inputTemplate)
 	if err != nil {
 		return nil, err
@@ -131,6 +132,7 @@ type htmlRenderer struct {
 }
 
 func (mr *htmlRenderer) Apply(template *Template) ([]byte, error) {
+	funcMap["SortServiceMethods"] = SortServiceMethods
 	tmpl, err := html_template.New("Text Template").Funcs(funcMap).Funcs(sprig.HtmlFuncMap()).Parse(mr.inputTemplate)
 	if err != nil {
 		return nil, err

--- a/template.go
+++ b/template.go
@@ -18,6 +18,7 @@ type Template struct {
 	Files []*File `json:"files"`
 	// Details about the scalar values and their respective types in supported languages.
 	Scalars []*ScalarValue `json:"scalarValueTypes"`
+	// Function Map usable within Templates
 }
 
 // NewTemplate creates a Template object from a set of descriptors.
@@ -534,6 +535,15 @@ func parseServiceMethod(pm *protokit.MethodDescriptor) *ServiceMethod {
 	}
 }
 
+func SortServiceMethods(methods []*ServiceMethod) orderedMethods {
+	sortedMethods := make(orderedMethods, 0, len(methods))
+	for _, method := range methods {
+		sortedMethods = append(sortedMethods, method)
+	}
+	sort.Sort(sortedMethods)
+	return sortedMethods
+}
+
 func baseName(name string) string {
 	parts := strings.Split(name, ".")
 	return parts[len(parts)-1]
@@ -597,3 +607,9 @@ type orderedServices []*Service
 func (os orderedServices) Len() int           { return len(os) }
 func (os orderedServices) Swap(i, j int)      { os[i], os[j] = os[j], os[i] }
 func (os orderedServices) Less(i, j int) bool { return os[i].LongName < os[j].LongName }
+
+type orderedMethods []*ServiceMethod
+
+func (om orderedMethods) Len() int           { return len(om) }
+func (om orderedMethods) Swap(i, j int)      { om[i], om[j] = om[j], om[i] }
+func (om orderedMethods) Less(i, j int) bool { return om[i].Name < om[j].Name }

--- a/template_test.go
+++ b/template_test.go
@@ -426,6 +426,22 @@ func TestServiceMethodProperties(t *testing.T) {
 	require.True(t, *method.Option(E_ExtendMethod.Name).(*bool))
 }
 
+func TestServiceMethodSorting(t *testing.T) {
+	service := findService("VehicleService", vehicleFile)
+
+	// verify 'by file' order by default
+	unsortedMethods := service.Methods
+	require.Equal(t, "GetModels", unsortedMethods[0].Name)
+	require.Equal(t, "AddModels", unsortedMethods[1].Name)
+	require.Equal(t, "GetVehicle", unsortedMethods[2].Name)
+
+	// verify 'a-z' order when sorted
+	sortedMethods := SortServiceMethods(service.Methods)
+	require.Equal(t, "AddModels", sortedMethods[0].Name)
+	require.Equal(t, "GetModels", sortedMethods[1].Name)
+	require.Equal(t, "GetVehicle", sortedMethods[2].Name)
+}
+
 func TestExcludedComments(t *testing.T) {
 	message := findMessage("ExcludedMessage", vehicleFile)
 	require.Empty(t, message.Description)


### PR DESCRIPTION
#### What is Changing?
Functionally nothing changes to existing setups. The changes I've implemented are meant to be entirely optional and access is provided through a function that can be called within the `.tmpl` files. Currently the **Order Guarantee** provides alphabetical access for a majority of the information available in a proto file but Service Methods can only be accessed in `file-order`. Service Methods can now optionally be fed through the SortServiceMethods function to get back an alphabetical listing.

#### How is it Changing?
No unorthodox implementation details were had to my knowledge. I wanted to provide the usage without modifying the default implementation so it was added as a function call. Beyond that, the needed parts are modeled after what is already there for Messages, Enums, etc...

#### What Could Go Wrong?
This is being tested through use in a personal project as well the added unit test in `template_test.go` In my opinion, there is no available risk in adding this as the default usage remains untouched and this simply adds some extra functionality which mirrors existing items.