### PR TITLE
Add support for camel casing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ build/examples: bin/protoc build tmp/googleapis examples/proto/*.proto examples/
 	@$(EXAMPLE_CMD) --doc_opt=html,example.html:Ignore* examples/proto/*.proto
 	@$(EXAMPLE_CMD) --doc_opt=json,example.json:Ignore* examples/proto/*.proto
 	@$(EXAMPLE_CMD) --doc_opt=markdown,example.md:Ignore* examples/proto/*.proto
+	@$(EXAMPLE_CMD) --doc_opt=markdown,example-camel-case-fields.md:Ignore*:camel_case_fields=true examples/proto/*.proto
 	@$(EXAMPLE_CMD) --doc_opt=examples/templates/asciidoc.tmpl,example.txt:Ignore* examples/proto/*.proto
 
 ##@: Dev
@@ -71,6 +72,7 @@ test/docker: bin/protoc tmp/googleapis release/snapshot ## Run the docker e2e te
 	@$(DOCKER_CMD) --doc_opt=html,example.html:Ignore*
 	@$(DOCKER_CMD) --doc_opt=json,example.json:Ignore*
 	@$(DOCKER_CMD) --doc_opt=markdown,example.md:Ignore*
+	@$(DOCKER_CMD) --doc_opt=markdown,example-camel-case-fields.md:Ignore*:camel_case_fields=true
 	@$(DOCKER_CMD) --doc_opt=/templates/asciidoc.tmpl,example.txt:Ignore*
 
 ##@: Release

--- a/examples/doc/example-camel-case-fields.md
+++ b/examples/doc/example-camel-case-fields.md
@@ -1,0 +1,316 @@
+# Protocol Documentation
+<a name="top"></a>
+
+## Table of Contents
+
+- [Booking.proto](#Booking-proto)
+    - [Booking](#com-example-Booking)
+    - [BookingStatus](#com-example-BookingStatus)
+    - [BookingStatusID](#com-example-BookingStatusID)
+    - [EmptyBookingMessage](#com-example-EmptyBookingMessage)
+  
+    - [BookingService](#com-example-BookingService)
+  
+- [Customer.proto](#Customer-proto)
+    - [Address](#com-example-Address)
+    - [Customer](#com-example-Customer)
+  
+- [Vehicle.proto](#Vehicle-proto)
+    - [Manufacturer](#com-example-Manufacturer)
+    - [Model](#com-example-Model)
+    - [Vehicle](#com-example-Vehicle)
+    - [Vehicle.Category](#com-example-Vehicle-Category)
+  
+    - [Manufacturer.Category](#com-example-Manufacturer-Category)
+  
+    - [File-level Extensions](#Vehicle-proto-extensions)
+  
+- [Scalar Value Types](#scalar-value-types)
+
+
+
+<a name="Booking-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## Booking.proto
+Booking related messages.
+
+This file is really just an example. The data model is completely
+fictional.
+
+
+<a name="com-example-Booking"></a>
+
+### Booking
+Represents the booking of a vehicle.
+
+Vehicles are some cool shit. But drive carefully!
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| vehicleId | [int32](#int32) |  | ID of booked vehicle. |
+| customerId | [int32](#int32) |  | Customer that booked the vehicle. |
+| status | [BookingStatus](#com-example-BookingStatus) |  | Status of the booking. |
+| confirmationSent | [bool](#bool) |  | Has booking confirmation been sent? |
+| paymentReceived | [bool](#bool) |  | Has payment been received? |
+| colorPreference | [string](#string) |  | **Deprecated.** Color preference of the customer. |
+
+
+
+
+
+
+<a name="com-example-BookingStatus"></a>
+
+### BookingStatus
+Represents the status of a vehicle booking.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [int32](#int32) |  | Unique booking status ID. |
+| description | [string](#string) |  | Booking status description. E.g. &#34;Active&#34;. |
+
+
+
+
+
+
+<a name="com-example-BookingStatusID"></a>
+
+### BookingStatusID
+Represents the booking status ID.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [int32](#int32) |  | Unique booking status ID. |
+
+
+
+
+
+
+<a name="com-example-EmptyBookingMessage"></a>
+
+### EmptyBookingMessage
+An empty message for testing
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+
+<a name="com-example-BookingService"></a>
+
+### BookingService
+Service for handling vehicle bookings.
+
+| Method Name | Request Type | Response Type | Description |
+| ----------- | ------------ | ------------- | ------------|
+| BookVehicle | [Booking](#com-example-Booking) | [BookingStatus](#com-example-BookingStatus) | Used to book a vehicle. Pass in a Booking and a BookingStatus will be returned. |
+| BookingUpdates | [BookingStatusID](#com-example-BookingStatusID) | [BookingStatus](#com-example-BookingStatus) stream | Used to subscribe to updates of the BookingStatus. |
+
+ 
+
+
+
+<a name="Customer-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## Customer.proto
+This file has messages for describing a customer.
+
+
+<a name="com-example-Address"></a>
+
+### Address
+Represents a mail address.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| addressLine1 | [string](#string) | required | First address line. |
+| addressLine2 | [string](#string) | optional | Second address line. |
+| addressLine3 | [string](#string) | optional | Second address line. |
+| town | [string](#string) | required | Address town. |
+| county | [string](#string) | optional | Address county, if applicable. |
+| country | [string](#string) | required | Address country. |
+
+
+
+
+
+
+<a name="com-example-Customer"></a>
+
+### Customer
+Represents a customer.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [int32](#int32) | required | Unique customer ID. |
+| firstName | [string](#string) | required | Customer first name. |
+| lastName | [string](#string) | required | Customer last name. |
+| details | [string](#string) | optional | Customer details. |
+| emailAddress | [string](#string) | optional | Customer e-mail address. |
+| phoneNumber | [string](#string) | repeated | Customer phone numbers, primary first. |
+| mailAddresses | [Address](#com-example-Address) | repeated | Customer mail addresses, primary first. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="Vehicle-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## Vehicle.proto
+Messages describing manufacturers / vehicles.
+
+
+<a name="com-example-Manufacturer"></a>
+
+### Manufacturer
+Represents a manufacturer of cars.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [int32](#int32) | required | The unique manufacturer ID. |
+| code | [string](#string) | required | A manufacturer code, e.g. &#34;DKL4P&#34;. |
+| details | [string](#string) | optional | Manufacturer details (minimum orders et.c.). |
+| category | [Manufacturer.Category](#com-example-Manufacturer-Category) | optional | Manufacturer category. Default: CATEGORY_EXTERNAL |
+
+
+
+
+
+
+<a name="com-example-Model"></a>
+
+### Model
+Represents a vehicle model.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) | required | The unique model ID. |
+| modelCode | [string](#string) | required | The car model code, e.g. &#34;PZ003&#34;. |
+| modelName | [string](#string) | required | The car model name, e.g. &#34;Z3&#34;. |
+| dailyHireRateDollars | [sint32](#sint32) | required | Dollars per day. |
+| dailyHireRateCents | [sint32](#sint32) | required | Cents per day. |
+
+
+
+
+
+
+<a name="com-example-Vehicle"></a>
+
+### Vehicle
+Represents a vehicle that can be hired.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [int32](#int32) | required | Unique vehicle ID. |
+| model | [Model](#com-example-Model) | required | Vehicle model. |
+| regNumber | [string](#string) | required | Vehicle registration number. |
+| mileage | [sint32](#sint32) | optional | Current vehicle mileage, if known. |
+| category | [Vehicle.Category](#com-example-Vehicle-Category) | optional | Vehicle category. |
+| dailyHireRateDollars | [sint32](#sint32) | optional | Dollars per day. Default: 50 |
+| dailyHireRateCents | [sint32](#sint32) | optional | Cents per day. |
+
+
+
+
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+| series | string | Model | 100 | Vehicle model series. |
+
+
+
+
+<a name="com-example-Vehicle-Category"></a>
+
+### Vehicle.Category
+Represents a vehicle category. E.g. &#34;Sedan&#34; or &#34;Truck&#34;.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| code | [string](#string) | required | Category code. E.g. &#34;S&#34;. |
+| description | [string](#string) | required | Category name. E.g. &#34;Sedan&#34;. |
+
+
+
+
+
+ 
+
+
+<a name="com-example-Manufacturer-Category"></a>
+
+### Manufacturer.Category
+Manufacturer category. A manufacturer may be either inhouse or external.
+
+| Name | Number | Description |
+| ---- | ------ | ----------- |
+| CATEGORY_INHOUSE | 0 | The manufacturer is inhouse. |
+| CATEGORY_EXTERNAL | 1 | The manufacturer is external. |
+
+
+ 
+
+
+<a name="Vehicle-proto-extensions"></a>
+
+### File-level Extensions
+| Extension | Type | Base | Number | Description |
+| --------- | ---- | ---- | ------ | ----------- |
+| country | string | Manufacturer | 100 | Manufacturer country. Default: `China` |
+
+ 
+
+ 
+
+
+
+## Scalar Value Types
+
+| .proto Type | Notes | C++ | Java | Python | Go | C# | PHP | Ruby |
+| ----------- | ----- | --- | ---- | ------ | -- | -- | --- | ---- |
+| <a name="double" /> double |  | double | double | float | float64 | double | float | Float |
+| <a name="float" /> float |  | float | float | float | float32 | float | float | Float |
+| <a name="int32" /> int32 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint32 instead. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="int64" /> int64 | Uses variable-length encoding. Inefficient for encoding negative numbers – if your field is likely to have negative values, use sint64 instead. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="uint32" /> uint32 | Uses variable-length encoding. | uint32 | int | int/long | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="uint64" /> uint64 | Uses variable-length encoding. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum or Fixnum (as required) |
+| <a name="sint32" /> sint32 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int32s. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sint64" /> sint64 | Uses variable-length encoding. Signed int value. These more efficiently encode negative numbers than regular int64s. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="fixed32" /> fixed32 | Always four bytes. More efficient than uint32 if values are often greater than 2^28. | uint32 | int | int | uint32 | uint | integer | Bignum or Fixnum (as required) |
+| <a name="fixed64" /> fixed64 | Always eight bytes. More efficient than uint64 if values are often greater than 2^56. | uint64 | long | int/long | uint64 | ulong | integer/string | Bignum |
+| <a name="sfixed32" /> sfixed32 | Always four bytes. | int32 | int | int | int32 | int | integer | Bignum or Fixnum (as required) |
+| <a name="sfixed64" /> sfixed64 | Always eight bytes. | int64 | long | int/long | int64 | long | integer/string | Bignum |
+| <a name="bool" /> bool |  | bool | boolean | boolean | bool | bool | boolean | TrueClass/FalseClass |
+| <a name="string" /> string | A string must always contain UTF-8 encoded or 7-bit ASCII text. | string | String | str/unicode | string | string | string | String (UTF-8) |
+| <a name="bytes" /> bytes | May contain any arbitrary sequence of bytes. | string | ByteString | str | []byte | ByteString | string | String (ASCII-8BIT) |
+

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/envoyproxy/protoc-gen-validate v1.0.2
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang/protobuf v1.5.3
+	github.com/golang/protobuf v1.5.4
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/mwitkow/go-proto-validators v0.3.2

--- a/go.sum
+++ b/go.sum
@@ -1435,8 +1435,9 @@ github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/golang/protobuf v1.5.1/go.mod h1:DopwsBzvsk0Fs44TXzsVbJyPhcCPeIwnvohx4u74HPM=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
-github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
+github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/golang/snappy v0.0.4/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=

--- a/plugin.go
+++ b/plugin.go
@@ -21,6 +21,7 @@ type PluginOptions struct {
 	OutputFile      string
 	ExcludePatterns []*regexp.Regexp
 	SourceRelative  bool
+	CamelCaseFields bool
 }
 
 // SupportedFeatures describes a flag setting for supported features.
@@ -53,7 +54,7 @@ func (p *Plugin) Generate(r *plugin_go.CodeGeneratorRequest) (*plugin_go.CodeGen
 	resp := new(plugin_go.CodeGeneratorResponse)
 	fdsGroup := groupProtosByDirectory(result, options.SourceRelative)
 	for dir, fds := range fdsGroup {
-		template := NewTemplate(fds)
+		template := NewTemplate(fds, options)
 
 		output, err := RenderTemplate(options.Type, template, customTemplate)
 		if err != nil {
@@ -107,18 +108,30 @@ OUTER:
 // ParseOptions parses plugin options from a CodeGeneratorRequest. It does this by splitting the `Parameter` field from
 // the request object and parsing out the type of renderer to use and the name of the file to be generated.
 //
-// The parameter (`--doc_opt`) must be of the format <TYPE|TEMPLATE_FILE>,<OUTPUT_FILE>[,default|source_relative]:<EXCLUDE_PATTERN>,<EXCLUDE_PATTERN>*.
+// The parameter (`--doc_opt`) must be of the format <TYPE|TEMPLATE_FILE>,<OUTPUT_FILE>[,default|source_relative]:<EXCLUDE_PATTERN>,<EXCLUDE_PATTERN>*:[,camel_case_fields=[true|false]].
 // The file will be written to the directory specified with the `--doc_out` argument to protoc.
 func ParseOptions(req *plugin_go.CodeGeneratorRequest) (*PluginOptions, error) {
 	options := &PluginOptions{
-		Type:           RenderTypeHTML,
-		TemplateFile:   "",
-		OutputFile:     "index.html",
-		SourceRelative: false,
+		Type:            RenderTypeHTML,
+		TemplateFile:    "",
+		OutputFile:      "index.html",
+		SourceRelative:  false,
+		CamelCaseFields: false,
 	}
 
 	params := req.GetParameter()
-	if strings.Contains(params, ":") {
+	colonParts := strings.Split(params, ":")
+	if len(colonParts) == 3 {
+		additionalOptions := (strings.Split(colonParts[2], "\n"))[0]
+		if additionalOptions == "camel_case_fields=true" {
+			options.CamelCaseFields = true
+		} else if additionalOptions == "camel_case_fields=false" {
+			options.CamelCaseFields = false
+		} else if additionalOptions != "" {
+			return nil, fmt.Errorf("Invalid additional options after second colon separator: %v", additionalOptions)
+		}
+	}
+	if len(colonParts) >= 2 {
 		// Parse out exclude patterns if any
 		parts := strings.Split(params, ":")
 		for _, pattern := range strings.Split(parts[1], ",") {
@@ -127,6 +140,9 @@ func ParseOptions(req *plugin_go.CodeGeneratorRequest) (*PluginOptions, error) {
 				return nil, err
 			}
 			options.ExcludePatterns = append(options.ExcludePatterns, r)
+		}
+		// Parse out any additional options, if any
+		if len(parts) > 2 {
 		}
 		// The first part is parsed below
 		params = parts[0]

--- a/plugin.go
+++ b/plugin.go
@@ -141,9 +141,6 @@ func ParseOptions(req *plugin_go.CodeGeneratorRequest) (*PluginOptions, error) {
 			}
 			options.ExcludePatterns = append(options.ExcludePatterns, r)
 		}
-		// Parse out any additional options, if any
-		if len(parts) > 2 {
-		}
 		// The first part is parsed below
 		params = parts[0]
 	}

--- a/renderer_test.go
+++ b/renderer_test.go
@@ -18,7 +18,7 @@ func TestRenderers(t *testing.T) {
 
 	req := utils.CreateGenRequest(set, "Booking.proto", "Vehicle.proto")
 	result := protokit.ParseCodeGenRequest(req)
-	template := NewTemplate(result)
+	template := NewTemplate(result, &PluginOptions{})
 
 	for _, r := range []RenderType{
 		RenderTypeDocBook,

--- a/template.go
+++ b/template.go
@@ -102,10 +102,7 @@ func mergeOptions(opts ...map[string]interface{}) map[string]interface{} {
 	return out
 }
 
-func maybeCamelCase(s string, makeCamelCase bool) string {
-	if !makeCamelCase {
-		return s
-	}
+func camelCase(s string) string {
 	var result strings.Builder
 
 	words := strings.Split(s, "_")
@@ -493,8 +490,13 @@ func parseMessageExtension(pe *protokit.ExtensionDescriptor) *MessageExtension {
 func parseMessageField(pf *protokit.FieldDescriptor, oneofDecls []*descriptor.OneofDescriptorProto, pluginOptions *PluginOptions) *MessageField {
 	t, lt, ft := parseType(pf)
 
+	name := pf.GetName()
+	if pluginOptions.CamelCaseFields {
+		name = camelCase(name)
+	}
+
 	m := &MessageField{
-		Name:         maybeCamelCase(pf.GetName(), pluginOptions.CamelCaseFields),
+		Name:         name,
 		Description:  description(pf.GetComments().String()),
 		Label:        labelName(pf.GetLabel(), pf.IsProto3(), pf.GetProto3Optional()),
 		Type:         t,

--- a/template_test.go
+++ b/template_test.go
@@ -29,14 +29,14 @@ func TestMain(m *testing.M) {
 	req := utils.CreateGenRequest(set, "Booking.proto", "Vehicle.proto")
 	result := protokit.ParseCodeGenRequest(req)
 
-	template = NewTemplate(result)
+	template = NewTemplate(result, &PluginOptions{CamelCaseFields: true})
 	bookingFile = template.Files[0]
 	vehicleFile = template.Files[1]
 
 	set, _ = utils.LoadDescriptorSet("fixtures", "cookie.pb")
 	req = utils.CreateGenRequest(set, "Cookie.proto")
 	result = protokit.ParseCodeGenRequest(req)
-	cookieTemplate = NewTemplate(result)
+	cookieTemplate = NewTemplate(result, &PluginOptions{})
 	cookieFile = cookieTemplate.Files[0]
 
 	os.Exit(m.Run())

--- a/template_test.go
+++ b/template_test.go
@@ -29,7 +29,7 @@ func TestMain(m *testing.M) {
 	req := utils.CreateGenRequest(set, "Booking.proto", "Vehicle.proto")
 	result := protokit.ParseCodeGenRequest(req)
 
-	template = NewTemplate(result, &PluginOptions{CamelCaseFields: true})
+	template = NewTemplate(result, &PluginOptions{})
 	bookingFile = template.Files[0]
 	vehicleFile = template.Files[1]
 


### PR DESCRIPTION
Introduce support for additional options that come after a second colon.

* Currently `doc_opts` takes the form of `<type>,<output>:<excludes>`
* This PR introduces the new structure of `<type>,<output>:<excludes>:<additional options>`.
* See the update to the `--doc_opt` comment for the full new structure details.
* This seems like a clean way to support the new `camel_case_fields` option, which is both backwards compatible without it being populated, and is forwards compatible with additional options being added.

Additional notes:
* I've implemented additional options parsing in a very simplistic way, splitting by `,` can be added later if needed.
* Passing plugin options seems like the most extensible way to support further additional options.
* I had to bump the protobuf dependency version for the master branch to build.

Fixes https://github.com/pseudomuto/protoc-gen-doc/issues/539 - looking closer, I don't think `docs_out` is possible, so this implements the desired functionality directly.