### PR TITLE
Issue #541: Add 'edition' support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 GORELEASER_BIN ?= https://github.com/goreleaser/goreleaser/releases/download/v1.5.0/goreleaser_Linux_x86_64.tar.gz
 REVIVE_BIN ?= https://github.com/mgechev/revive/releases/download/v1.1.4/revive_1.1.4_Linux_x86_64.tar.gz
-PROTOC_BIN ?= https://github.com/protocolbuffers/protobuf/releases/download/v3.19.4/protoc-3.19.4-linux-x86_64.zip
+PROTOC_BIN ?= https://github.com/protocolbuffers/protobuf/releases/download/v32.0/protoc-32.0-linux-x86_64.zip
 
 EXAMPLE_DIR=$(PWD)/examples
 DOCS_DIR=$(EXAMPLE_DIR)/doc

--- a/examples/doc/example-camel-case-fields.md
+++ b/examples/doc/example-camel-case-fields.md
@@ -15,6 +15,9 @@
     - [Address](#com-example-Address)
     - [Customer](#com-example-Customer)
   
+- [Milk.proto](#Milk-proto)
+    - [Milk](#com-example-Milk)
+  
 - [Vehicle.proto](#Vehicle-proto)
     - [Manufacturer](#com-example-Manufacturer)
     - [Model](#com-example-Model)
@@ -164,6 +167,39 @@ Represents a customer.
 | emailAddress | [string](#string) | optional | Customer e-mail address. |
 | phoneNumber | [string](#string) | repeated | Customer phone numbers, primary first. |
 | mailAddresses | [Address](#com-example-Address) | repeated | Customer mail addresses, primary first. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="Milk-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## Milk.proto
+
+
+
+<a name="com-example-Milk"></a>
+
+### Milk
+Represents a milk.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) | optional | The id of the milk. |
+| name | [string](#string) | optional | The name of the milk. |
+| volume | [int32](#int32) | optional | The volume of the milk. |
 
 
 

--- a/examples/doc/example.docbook
+++ b/examples/doc/example.docbook
@@ -365,6 +365,66 @@
   </section>
   
   <section>
+    <title>Milk.proto</title>
+    <para></para>
+    
+    <section id="com.example.Milk">
+      <title>Milk</title>
+      <para>Represents a milk.</para>
+      
+      <table frame="all">
+        <title><classname>Milk</classname> Fields</title>
+        <tgroup cols="4">
+          <colspec colwidth="*"/>
+          <colspec colwidth="*"/>
+          <colspec colwidth="0.5*"/>
+          <colspec colwidth="3*"/>
+          <thead>
+            <row>
+              <entry>Field</entry>
+              <entry>Type</entry>
+              <entry>Label</entry>
+              <entry>Description</entry>
+            </row>
+          </thead>
+          <tbody>
+            
+            <row>
+              <entry>id</entry>
+              <entry><link linkend="string">string</link></entry>
+              <entry>optional</entry>
+              <entry><para>The id of the milk.</para></entry>
+            </row>
+            
+            <row>
+              <entry>name</entry>
+              <entry><link linkend="string">string</link></entry>
+              <entry>optional</entry>
+              <entry><para>The name of the milk.</para></entry>
+            </row>
+            
+            <row>
+              <entry>volume</entry>
+              <entry><link linkend="int32">int32</link></entry>
+              <entry>optional</entry>
+              <entry><para>The volume of the milk.</para></entry>
+            </row>
+            
+          </tbody>
+        </tgroup>
+      </table>
+      
+      
+    </section>
+    
+    
+
+    
+
+    
+  </section>
+  
+  <section>
     <title>Vehicle.proto</title>
     <para>Messages describing manufacturers / vehicles.</para>
     

--- a/examples/doc/example.html
+++ b/examples/doc/example.html
@@ -225,6 +225,21 @@
         
           
           <li>
+            <a href="#Milk.proto">Milk.proto</a>
+            <ul>
+              
+                <li>
+                  <a href="#com.example.Milk"><span class="badge">M</span>Milk</a>
+                </li>
+              
+              
+              
+              
+            </ul>
+          </li>
+        
+          
+          <li>
             <a href="#Vehicle.proto">Vehicle.proto</a>
             <ul>
               
@@ -625,6 +640,58 @@
                   <td><a href="#com.example.Address">Address</a></td>
                   <td>repeated</td>
                   <td><p>Customer mail addresses, primary first. </p></td>
+                </tr>
+              
+            </tbody>
+          </table>
+
+          
+
+        
+      
+
+      
+
+      
+
+      
+    
+      
+      <div class="file-heading">
+        <h2 id="Milk.proto">Milk.proto</h2><a href="#title">Top</a>
+      </div>
+      <p></p>
+
+      
+        <h3 id="com.example.Milk">Milk</h3>
+        <p>Represents a milk.</p>
+
+        
+          <table class="field-table">
+            <thead>
+              <tr><td>Field</td><td>Type</td><td>Label</td><td>Description</td></tr>
+            </thead>
+            <tbody>
+              
+                <tr>
+                  <td>id</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>The id of the milk. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>name</td>
+                  <td><a href="#string">string</a></td>
+                  <td>optional</td>
+                  <td><p>The name of the milk. </p></td>
+                </tr>
+              
+                <tr>
+                  <td>volume</td>
+                  <td><a href="#int32">int32</a></td>
+                  <td>optional</td>
+                  <td><p>The volume of the milk. </p></td>
                 </tr>
               
             </tbody>

--- a/examples/doc/example.json
+++ b/examples/doc/example.json
@@ -423,6 +423,68 @@
       "services": []
     },
     {
+      "name": "Milk.proto",
+      "description": "",
+      "package": "com.example",
+      "hasEnums": false,
+      "hasExtensions": false,
+      "hasMessages": true,
+      "hasServices": false,
+      "enums": [],
+      "extensions": [],
+      "messages": [
+        {
+          "name": "Milk",
+          "longName": "Milk",
+          "fullName": "com.example.Milk",
+          "description": "Represents a milk.",
+          "hasExtensions": false,
+          "hasFields": true,
+          "hasOneofs": false,
+          "extensions": [],
+          "fields": [
+            {
+              "name": "id",
+              "description": "The id of the milk.",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "name",
+              "description": "The name of the milk.",
+              "label": "optional",
+              "type": "string",
+              "longType": "string",
+              "fullType": "string",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            },
+            {
+              "name": "volume",
+              "description": "The volume of the milk.",
+              "label": "optional",
+              "type": "int32",
+              "longType": "int32",
+              "fullType": "int32",
+              "ismap": false,
+              "isoneof": false,
+              "oneofdecl": "",
+              "defaultValue": ""
+            }
+          ]
+        }
+      ],
+      "services": []
+    },
+    {
       "name": "Vehicle.proto",
       "description": "Messages describing manufacturers / vehicles.",
       "package": "com.example",

--- a/examples/doc/example.md
+++ b/examples/doc/example.md
@@ -15,6 +15,9 @@
     - [Address](#com-example-Address)
     - [Customer](#com-example-Customer)
   
+- [Milk.proto](#Milk-proto)
+    - [Milk](#com-example-Milk)
+  
 - [Vehicle.proto](#Vehicle-proto)
     - [Manufacturer](#com-example-Manufacturer)
     - [Model](#com-example-Model)
@@ -164,6 +167,39 @@ Represents a customer.
 | email_address | [string](#string) | optional | Customer e-mail address. |
 | phone_number | [string](#string) | repeated | Customer phone numbers, primary first. |
 | mail_addresses | [Address](#com-example-Address) | repeated | Customer mail addresses, primary first. |
+
+
+
+
+
+ 
+
+ 
+
+ 
+
+ 
+
+
+
+<a name="Milk-proto"></a>
+<p align="right"><a href="#top">Top</a></p>
+
+## Milk.proto
+
+
+
+<a name="com-example-Milk"></a>
+
+### Milk
+Represents a milk.
+
+
+| Field | Type | Label | Description |
+| ----- | ---- | ----- | ----------- |
+| id | [string](#string) | optional | The id of the milk. |
+| name | [string](#string) | optional | The name of the milk. |
+| volume | [int32](#int32) | optional | The volume of the milk. |
 
 
 

--- a/examples/doc/example.txt
+++ b/examples/doc/example.txt
@@ -124,6 +124,30 @@ Represents a customer.
 
 
 
+== Milk.proto
+
+
+
+=== Milk
+Represents a milk.
+
+
+|===========================================
+|*Field* |*Type* |*Label* |*Description*
+
+|id | <<string,string>> |optional |The id of the milk.
+
+|name | <<string,string>> |optional |The name of the milk.
+
+|volume | <<int32,int32>> |optional |The volume of the milk.
+
+|===========================================
+
+
+
+
+
+
 == Vehicle.proto
 
 

--- a/examples/proto/Milk.proto
+++ b/examples/proto/Milk.proto
@@ -1,0 +1,12 @@
+edition = "2024";
+
+package com.example;
+
+/**
+ * Represents a milk.
+ */
+message Milk {
+  string id = 1; // The id of the milk.
+  string name = 2; // The name of the milk.
+  int32 volume = 3; // The volume of the milk.
+}

--- a/plugin.go
+++ b/plugin.go
@@ -68,6 +68,8 @@ func (p *Plugin) Generate(r *plugin_go.CodeGeneratorRequest) (*plugin_go.CodeGen
 	}
 
 	resp.SupportedFeatures = proto.Uint64(SupportedFeatures)
+	resp.MinimumEdition = proto.Int32(900)  // Edition_EDITION_LEGACY
+	resp.MaximumEdition = proto.Int32(1001) // Edition_EDITION_2024
 
 	return resp, nil
 }

--- a/plugin.go
+++ b/plugin.go
@@ -25,7 +25,7 @@ type PluginOptions struct {
 }
 
 // SupportedFeatures describes a flag setting for supported features.
-var SupportedFeatures = uint64(plugin_go.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL)
+var SupportedFeatures = uint64(plugin_go.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS)
 
 // Plugin describes a protoc code generate plugin. It's an implementation of Plugin from github.com/pseudomuto/protokit
 type Plugin struct{}


### PR DESCRIPTION
The problem was highlighted in #541 

**What is Changing?**
The plugin's response has been changed so that its supports working with the [edition](https://protobuf.dev/editions/overview/). 

**How is it Changing?**
The changes are quite simple. Two fields were added to the plugin's response: `MinimumEdition` and `MaximumEdition`. Also the `SupportedFeatures` flag has been changed to `CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS`. An example of simple proto file that use **editions** added.

**What Could Go Wrong?**
Perhaps the innovations in the syntax of the message fields will somehow be poorly handled, but in the added simplest example `Milk.proto` everything works as it should. In addition to this simple example, I can say that on my work project, a large proto file generated the documentation correctly. 